### PR TITLE
feat: S3 integration creates presigned urls for multiple directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - (digiwf-form-builder): validation of list items
+- (digiwf-s3-integration):  supports creation of presigned urls for multiple file paths
+- (digiwf-cosys-integration): allow to use any s3 storage with the cosys integration (domain specific s3 storage)
 
 ### Fixed
 

--- a/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-client-example/src/main/resources/s3-client.http
+++ b/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-client-example/src/main/resources/s3-client.http
@@ -1,0 +1,9 @@
+# get presigned url
+POST http://localhost:8081/presignedurl
+Content-Type: application/json
+Accept: application/json
+
+{
+  "path": "folder/first.txt;folder/second.txt;folder/third.txt",
+  "action": "GET"
+}

--- a/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-core/src/main/java/io/muenchendigital/digiwf/s3/integration/api/streaming/MessageProcessor.java
+++ b/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-core/src/main/java/io/muenchendigital/digiwf/s3/integration/api/streaming/MessageProcessor.java
@@ -54,7 +54,7 @@ public class MessageProcessor {
 
             try {
                 // 7 days is max expiration
-                final List<PresignedUrl> presignedUrls = this.fileHandlingService.getPresignedUrls(event.getPath(), Method.valueOf(event.getAction()), this.presignedUrlExpiresInMinutes);
+                final List<PresignedUrl> presignedUrls = this.fileHandlingService.getPresignedUrls(List.of(event.getPath().split(";")), Method.valueOf(event.getAction()), this.presignedUrlExpiresInMinutes);
                 this.emitResponse(message.getHeaders(), presignedUrls);
             } catch (final S3AccessException | FileExistanceException e) {
                 throw new RuntimeException(e);

--- a/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-core/src/main/java/io/muenchendigital/digiwf/s3/integration/domain/service/FileHandlingService.java
+++ b/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-core/src/main/java/io/muenchendigital/digiwf/s3/integration/domain/service/FileHandlingService.java
@@ -45,6 +45,18 @@ public class FileHandlingService {
         return this.getPresignedUrls(paths, action, expiresInMinutes, Optional.empty());
     }
 
+    /**
+     * Get a list of presigned urls for all files in the paths.
+     * If the path is a file the presigned url for the file is returned.
+     *
+     * @param paths            list of paths to files and/or folders
+     * @param action           http method for the presigned url
+     * @param expiresInMinutes presigned url expiration time
+     * @param endOfLife        the files endOfLife
+     * @return
+     * @throws S3AccessException
+     * @throws FileExistanceException
+     */
     public List<PresignedUrl> getPresignedUrls(final List<String> paths, final Method action, final int expiresInMinutes, final Optional<LocalDate> endOfLife) throws S3AccessException, FileExistanceException {
         final List<PresignedUrl> presignedUrls = new ArrayList<>();
         for (String p : paths) {

--- a/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-core/src/main/java/io/muenchendigital/digiwf/s3/integration/domain/service/FileHandlingService.java
+++ b/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-core/src/main/java/io/muenchendigital/digiwf/s3/integration/domain/service/FileHandlingService.java
@@ -31,18 +31,26 @@ public class FileHandlingService {
     private final FileRepository fileRepository;
 
     /**
-     * Get a list of presigned urls for all files in the path.
+     * Get a list of presigned urls for all files in the paths.
      * If the path is a file the presigned url for the file is returned.
      *
-     * @param path             path to file or folder
+     * @param paths            list of paths to files and/or folders
      * @param action           http method for the presigned url
      * @param expiresInMinutes presigned url expiration time
      * @return
      * @throws S3AccessException
      * @throws FileExistanceException
      */
-    public List<PresignedUrl> getPresignedUrls(final String path, final Method action, final int expiresInMinutes) throws S3AccessException, FileExistanceException {
-        return this.getPresignedUrls(path, action, expiresInMinutes, Optional.empty());
+    public List<PresignedUrl> getPresignedUrls(final List<String> paths, final Method action, final int expiresInMinutes) throws S3AccessException, FileExistanceException {
+        return this.getPresignedUrls(paths, action, expiresInMinutes, Optional.empty());
+    }
+
+    public List<PresignedUrl> getPresignedUrls(final List<String> paths, final Method action, final int expiresInMinutes, final Optional<LocalDate> endOfLife) throws S3AccessException, FileExistanceException {
+        final List<PresignedUrl> presignedUrls = new ArrayList<>();
+        for (String p : paths) {
+            presignedUrls.addAll(this.getPresignedUrls(p, action, expiresInMinutes, endOfLife));
+        }
+        return presignedUrls;
     }
 
     /**

--- a/digiwf-integrations/digiwf-s3-integration/docs/documentation.md
+++ b/digiwf-integrations/digiwf-s3-integration/docs/documentation.md
@@ -126,6 +126,8 @@ storage.
 If you request a file directly you just get the presigned url for the file.
 If you request presigned urls for a directory presigned urls for all files inside the directory are created.
 
+In the `path` you can specify multiple file paths by concatenating them with a semicolon `;` (e.g. `folder/first.txt;folder/second.txt;folder/third.txt`).
+
 _For more examples, please refer to
 the [example-s3-integration](https://github.com/it-at-m/digiwf-s3-integration/tree/dev/example-s3-integration)
 and/or [example-s3-integration-client](https://github.com/it-at-m/digiwf-s3-integration/tree/dev/example-s3-integration-client)

--- a/stack/docker-compose.yml
+++ b/stack/docker-compose.yml
@@ -32,6 +32,8 @@ services:
     ports:
       - '9000:9000'
       - '9001:9001'
+    volumes:
+      - /docker/minio:/data
 
   mailhog:
     image: mailhog/mailhog:latest


### PR DESCRIPTION
---
name: Pull request
about: Contribute your changes to the project
title: '[pull-request]'
labels: ''
assignees: ''
---
**Description**

- S3 integration supports creation of presigned urls for multiple file paths
- Minor improvements of the `docker-compose.yml`

**Reference**
Issues #51 

**Checklist**

- [ ] Acceptance criteria are met
- [ ] Pipeline has been run successfully
- [ ] JUnit tests have been run successfully
- [ ] Changelog is adjusted
- [ ] [Documentations](https://git.muenchen.de/groups/digitalisierung/-/wikis/Dokumentationen) are completed
- [ ] Frontend is tested
- [ ] Created sub-branches are deleted
- [ ] Boards are updated ( [Digitalisierung](https://git.muenchen.de/groups/digitalisierung/-/boards) , [Support](https://git.muenchen.de/digitalisierung/digiwf-support) , [Zenhub](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) )
- [ ] feature process is created or extended
- [ ] [git-ops](https://git.muenchen.de/digitalisierung/digiwf-ops) is customized
- [ ] Openshift environments are prepared (Secrets, etc.)
