### PR TITLE
fix: Cannot resolve identifier 'app_file_s3_async_config' on process …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 ### Fixed
 
 - (digiwf-engine) added a `no-ldap` profile for development
+- (digiwf-engine) cannot resolve identifier 'app_file_s3_async_config' on process start bug
 
 ## [core 0.11.0] - 2022-08-30
 


### PR DESCRIPTION
…start

---
name: Pull request
about: Contribute your changes to the project
title: '[pull-request]'
labels: ''
assignees: ''
---
**Description**
Use default s3 config from application.properties on process start if no process config is available

**Reference**
Issues https://github.com/it-at-m/digiwf-project/issues/385

**Checklist**

- [ ] Acceptance criteria are met
- [ ] Pipeline has been run successfully
- [ ] JUnit tests have been run successfully
- [ ] Changelog is adjusted
- [ ] [Documentations](https://git.muenchen.de/groups/digitalisierung/-/wikis/Dokumentationen) are completed
- [ ] Frontend is tested
- [ ] Created sub-branches are deleted
- [ ] Boards are updated ( [Digitalisierung](https://git.muenchen.de/groups/digitalisierung/-/boards) , [Support](https://git.muenchen.de/digitalisierung/digiwf-support) , [Zenhub](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) )
- [ ] feature process is created or extended
- [ ] [git-ops](https://git.muenchen.de/digitalisierung/digiwf-ops) is customized
- [ ] Openshift environments are prepared (Secrets, etc.)
