### PR TITLE
feat: log more information on violated json schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 - engine
     - whitelist regex in application.properties
+    - Improved logging of `DigiWFValidationException`
 
 ## [apps 0.21.0] - 2022-11-27
 

--- a/digiwf-engine/digiwf-engine-service/src/main/java/io/muenchendigital/digiwf/shared/exception/RestExceptionHandler.java
+++ b/digiwf-engine/digiwf-engine-service/src/main/java/io/muenchendigital/digiwf/shared/exception/RestExceptionHandler.java
@@ -4,6 +4,7 @@
 
 package io.muenchendigital.digiwf.shared.exception;
 
+import io.muenchendigital.digiwf.json.validation.DigiWFValidationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -32,7 +33,7 @@ public class RestExceptionHandler
                 new HttpHeaders(), HttpStatus.NOT_FOUND, request);
     }
 
-    @ExceptionHandler(value = {VariablesNotValidException.class, NoFileContextException.class})
+    @ExceptionHandler(value = {VariablesNotValidException.class, NoFileContextException.class, DigiWFValidationException.class})
     protected ResponseEntity<Object> handleBadRequest(final RuntimeException ex, final WebRequest request) {
         final String bodyOfResponse = "Bad request";
         log.error("Client Exception 400.", ex);

--- a/digiwf-libs/digiwf-json-serialization/digiwf-json-serialization-core/src/main/java/io/muenchendigital/digiwf/json/validation/JsonSchemaValidator.java
+++ b/digiwf-libs/digiwf-json-serialization/digiwf-json-serialization-core/src/main/java/io/muenchendigital/digiwf/json/validation/JsonSchemaValidator.java
@@ -29,7 +29,7 @@ public class JsonSchemaValidator {
     public void validate(final Map<String, Object> schema, final Map<String, Object> data) {
         try {
             this.validate(schema, new JSONObject(data));
-        } catch (ValidationException validationException) {
+        } catch (final ValidationException validationException) {
             final List<ValidationErrorInformation> errorInformation = this.extractValidationErrorInformation(validationException);
             throw new DigiWFValidationException(errorInformation);
         }
@@ -57,10 +57,6 @@ public class JsonSchemaValidator {
                 .stream().map(this::extractValidationErrorInformation)
                 .flatMap(Collection::stream)
                 .collect(Collectors.toList());
-
-        if (validationException.getSchemaLocation() == null || !validationException.getCausingExceptions().isEmpty()) {
-            return errors;
-        }
 
         final ValidationErrorInformation validationErrorInformation = new ValidationErrorInformation(
                 validationException.getPointerToViolation(),

--- a/digiwf-libs/digiwf-json-serialization/digiwf-json-serialization-core/src/test/java/io/muenchendigital/digiwf/json/validation/JsonValidatorTest.java
+++ b/digiwf-libs/digiwf-json-serialization/digiwf-json-serialization-core/src/test/java/io/muenchendigital/digiwf/json/validation/JsonValidatorTest.java
@@ -128,7 +128,7 @@ public class JsonValidatorTest {
             this.validationService.validate(new JSONObject(rawSchema).toMap(), acutalData);
         });
 
-        assertThat(exception.getMessage()).isEqualTo("ValidationErrorInformation(pointer=#/objekt1, schemaPath=#/allOf/0/allOf/1/properties/objekt1, violatedSchema={\"type\":\"object\",\"additionalProperties\":false,\"title\":\"Dynamisches Objekt\",\"description\":\"fsdafsdafsad\",\"x-rules\":[],\"fieldType\":\"object\",\"x-options\":{\"fieldColProps\":{\"messages\":{},\"cols\":12,\"sm\":12}},\"key\":\"d6d8d7a1-e812-42ac-9135-8242f93b6158\",\"x-props\":{\"outlined\":true,\"dense\":true},\"properties\":{\"objektSchalter\":{\"title\":\"Schalter\",\"x-rules\":[],\"x-display\":\"switch\",\"x-options\":{\"fieldColProps\":{\"messages\":{},\"cols\":12,\"sm\":12}},\"fieldType\":\"switch\",\"key\":\"ObjektSchalter\",\"x-props\":{\"outlined\":true,\"dense\":true},\"type\":\"boolean\"},\"objektTextfeld\":{\"type\":\"string\",\"title\":\"Textfeld\",\"x-rules\":[],\"fieldType\":\"text\",\"x-options\":{\"fieldColProps\":{\"messages\":{},\"cols\":12,\"sm\":12}},\"key\":\"objektTextfeld\",\"x-props\":{\"outlined\":true,\"dense\":true}}}}, message=#/objekt1: extraneous key [objektTextfeld1] is not permitted)");
+        assertThat(exception.getMessage()).contains("ValidationErrorInformation(pointer=#/objekt1, schemaPath=#/allOf/0/allOf/1/properties/objekt1, violatedSchema={\"type\":\"object\",\"additionalProperties\":false,\"title\":\"Dynamisches Objekt\",\"description\":\"fsdafsdafsad\",\"x-rules\":[],\"fieldType\":\"object\",\"x-options\":{\"fieldColProps\":{\"messages\":{},\"cols\":12,\"sm\":12}},\"key\":\"d6d8d7a1-e812-42ac-9135-8242f93b6158\",\"x-props\":{\"outlined\":true,\"dense\":true},\"properties\":{\"objektSchalter\":{\"title\":\"Schalter\",\"x-rules\":[],\"x-display\":\"switch\",\"x-options\":{\"fieldColProps\":{\"messages\":{},\"cols\":12,\"sm\":12}},\"fieldType\":\"switch\",\"key\":\"ObjektSchalter\",\"x-props\":{\"outlined\":true,\"dense\":true},\"type\":\"boolean\"},\"objektTextfeld\":{\"type\":\"string\",\"title\":\"Textfeld\",\"x-rules\":[],\"fieldType\":\"text\",\"x-options\":{\"fieldColProps\":{\"messages\":{},\"cols\":12,\"sm\":12}},\"key\":\"objektTextfeld\",\"x-props\":{\"outlined\":true,\"dense\":true}}}}, message=#/objekt1: extraneous key [objektTextfeld1] is not permitted)");
 
     }
 
@@ -143,7 +143,7 @@ public class JsonValidatorTest {
             this.validationService.validate(new JSONObject(rawSchema).toMap(), acutalData);
         });
 
-        assertThat(exception.getValidationErrorInformation().size()).isEqualTo(2);
+        assertThat(exception.getValidationErrorInformation().size()).isEqualTo(5);
     }
 
     @Test

--- a/digiwf-libs/digiwf-json-serialization/digiwf-json-serialization-core/src/test/java/io/muenchendigital/digiwf/json/validation/JsonValidatorTest.java
+++ b/digiwf-libs/digiwf-json-serialization/digiwf-json-serialization-core/src/test/java/io/muenchendigital/digiwf/json/validation/JsonValidatorTest.java
@@ -143,7 +143,7 @@ public class JsonValidatorTest {
             this.validationService.validate(new JSONObject(rawSchema).toMap(), acutalData);
         });
 
-        assertThat(exception.getValidationErrorInformation().size()).isEqualTo(5);
+        assertThat(exception.getValidationErrorInformation().size()).isEqualTo(8);
     }
 
     @Test


### PR DESCRIPTION
---
name: Pull request
about: Contribute your changes to the project
title: '[pull-request]'
labels: ''
assignees: ''
---
**Description**

- `DigiWFValidationException` causes *500 Internal Server Error* without further information. I changed the `RestExceptionHandler` to log the exception properly and return *400 Bad Request*
- Improved the mapping of Json Schema `ValidationException` to `DigiWFValidationException` to include more information

**Reference**
Issues https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/issues/it-at-m/digiwf-project/434

**Checklist**

- [ ] Acceptance criteria are met
- [x] Pipeline has been run successfully
- [x] JUnit tests have been run successfully
- [x] Changelog is adjusted
- [ ] [Documentations](https://git.muenchen.de/groups/digitalisierung/-/wikis/Dokumentationen) are completed
- [ ] Frontend is tested
- [ ] Created sub-branches are deleted
- [x] Boards are updated ( [Digitalisierung](https://git.muenchen.de/groups/digitalisierung/-/boards) , [Support](https://git.muenchen.de/digitalisierung/digiwf-support) , [Zenhub](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) )
- [ ] feature process is created or extended
- [ ] [git-ops](https://git.muenchen.de/digitalisierung/digiwf-ops) is customized
- [ ] Openshift environments are prepared (Secrets, etc.)
