### PR TITLE
chore: add docs building capability without locally installed node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -398,3 +398,4 @@ gradle-app.setting
 /digiwf-schema-registry/digiwf-schema-registry-client/.swagger-codegen-ignore
 **/pom.xml.versionsBackup
 **/application-internal.*
+/docs/node/

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,26 @@
 # DigiWF Docs
 
+## With local Node
+
 ```bash
 npm install
 npm run dev
 ```
+
+## Without local Node
+
+Execute once to get local Node / NPM on your machine and install required modules:
+```bash
+mvn -f docs install -Pdocs
+```
+
+For the local development you can use: 
+```bash
+mvn -f docs -Pdocs -Pdev package
+```
+Open http://localhost:8080/ to serve the docs with life preview.
+
+
 
 ## Document new features and bugfixes
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -53,26 +53,6 @@
             <artifactId>frontend-maven-plugin</artifactId>
             <executions>
               <execution>
-                <id>npm-clean</id>
-                <goals>
-                  <goal>npm</goal>
-                </goals>
-                <phase>clean</phase>
-                <configuration>
-                  <arguments>run clean</arguments>
-                </configuration>
-              </execution>
-              <execution>
-                <id>lerna-refresh</id>
-                <goals>
-                  <goal>npm</goal>
-                </goals>
-                <phase>generate-sources</phase>
-                <configuration>
-                  <arguments>run refresh</arguments>
-                </configuration>
-              </execution>
-              <execution>
                 <id>npm run build</id>
                 <goals>
                   <goal>npm</goal>
@@ -81,17 +61,6 @@
                   <arguments>run build</arguments>
                 </configuration>
               </execution>
-              <execution>
-                <id>npm run test</id>
-                <goals>
-                  <goal>npm</goal>
-                </goals>
-                <phase>test</phase>
-                <configuration>
-                  <arguments>run test</arguments>
-                </configuration>
-              </execution>
-
             </executions>
           </plugin>
           <plugin>
@@ -108,7 +77,7 @@
     </profile>
 
     <profile>
-      <id>serve</id>
+      <id>dev</id>
       <build>
         <plugins>
           <plugin>
@@ -116,58 +85,12 @@
             <artifactId>frontend-maven-plugin</artifactId>
             <executions>
               <execution>
-                <id>serve</id>
+                <id>run-dev</id>
                 <goals>
                   <goal>npm</goal>
                 </goals>
                 <configuration>
-                  <arguments>run serve:all</arguments>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <id>serve-tasklist</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.github.eirslett</groupId>
-            <artifactId>frontend-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>serve-tasklist</id>
-                <goals>
-                  <goal>npm</goal>
-                </goals>
-                <configuration>
-                  <arguments>run serve:tasklist</arguments>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <id>serve-forms</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.github.eirslett</groupId>
-            <artifactId>frontend-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>serve-forms</id>
-                <goals>
-                  <goal>npm</goal>
-                </goals>
-                <configuration>
-                  <arguments>run serve:forms</arguments>
+                  <arguments>run dev</arguments>
                 </configuration>
               </execution>
             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -235,6 +235,12 @@
                 <module>digiwf-apps</module>
             </modules>
         </profile>
+        <profile>
+            <id>docs</id>
+            <modules>
+                <module>docs</module>
+            </modules>
+        </profile>
 
         <!-- Deployment profile (required so these plugins are only used when deploying) -->
 


### PR DESCRIPTION
**Description**

Docs are built with vue and should not require a local Node installation. This PR fixes this issue.

