### PR TITLE
#532: set page to 0 when changing search term

### DIFF
--- a/digiwf-apps/packages/apps/digiwf-tasklist/src/middleware/paginationData.ts
+++ b/digiwf-apps/packages/apps/digiwf-tasklist/src/middleware/paginationData.ts
@@ -66,6 +66,7 @@ export const useGetPaginationData = (): PaginationData => {
         filter: newSearchQuery
       }
     });
+    setPage(0);
   }
   return {
     searchQuery,


### PR DESCRIPTION
**Description**

Jumps to first page when the user changes the value of the search field

**Reference**

Issues: https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/issues/gh/it-at-m/digiwf-project/532 
