### PR TITLE
fix(local-setup): docker compose wait for init-keycloak to finish before starting digiwf-gateway

### DIFF
--- a/stack/docker-compose.yml
+++ b/stack/docker-compose.yml
@@ -92,7 +92,8 @@ services:
   digiwf-gateway:
     image: itatm/digiwf-gateway:dev
     depends_on:
-      - keycloak
+      init-keycloak:
+        condition: service_completed_successfully
     env_file:
       - local-docker.env
     ports:


### PR DESCRIPTION
**Description**

Wait for init-keycloak to finish before starting the digiwf-gateway. Otherwise the digiwf-gateway crashes on the first docker compose run

**Reference**

Issues #None
