### PR TITLE
Feature/invoke polyflow assing on assingment via listener

### DIFF
--- a/digiwf-engine/digiwf-engine-service/src/main/java/io/muenchendigital/digiwf/shared/configuration/SecurityConfiguration.java
+++ b/digiwf-engine/digiwf-engine-service/src/main/java/io/muenchendigital/digiwf/shared/configuration/SecurityConfiguration.java
@@ -36,6 +36,9 @@ public class SecurityConfiguration {
       "/swagger-ui/index.html", // allow access to swagger
       "/swagger-ui*/*swagger-initializer.js", // allow access to swagger
       "/swagger-ui*/**", // allow access to swagger
+      "/v3/api-docs/*", // allow access to swagger
+      "/v3/api-docs", // allow access to swagger
+      "/camunda/**" // allow access to camunda cockpit
   };
 
   private final RestTemplateBuilder restTemplateBuilder;

--- a/digiwf-task/digiwf-polyflow-connector-starter/src/main/java/io/muenchendigital/digiwf/task/listener/AssignmentAssignTaskListener.java
+++ b/digiwf-task/digiwf-polyflow-connector-starter/src/main/java/io/muenchendigital/digiwf/task/listener/AssignmentAssignTaskListener.java
@@ -1,5 +1,8 @@
 package io.muenchendigital.digiwf.task.listener;
 
+import io.holunda.camunda.taskpool.api.task.AssignTaskCommand;
+import io.holunda.camunda.taskpool.api.task.CamundaTaskEventType;
+import io.holunda.camunda.taskpool.api.task.EngineTaskCommandSorterKt;
 import io.holunda.polyflow.taskpool.collector.task.TaskEventCollectorService;
 import io.muenchendigital.digiwf.task.TaskManagementProperties;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +24,7 @@ public class AssignmentAssignTaskListener {
 
     @Order(TaskEventCollectorService.ORDER - 1000) // be before polyflow
     @EventListener(condition = "#task.eventName.equals('assignment')")
-    public void taskAssigned(final DelegateTask task) {
+    public AssignTaskCommand taskAssigned(final DelegateTask task) {
 
         if (properties.isShadow()) {
             val assignee = task.getAssignee();
@@ -33,10 +36,21 @@ public class AssignmentAssignTaskListener {
                 log.debug("Shadowing assignment information for task {} in global variable: {}", task.getId(), assignee);
                 writer.set(TASK_ASSIGNEE, assignee);
             }
+
             if (properties.isDelete()) {
                 log.debug("Deleting assignment information from task attributes {}", task.getId());
                 task.setAssignee(null);
             }
+
+            // emitting an event in event listener will cause the collector to pick it up.
+            // manual assignment
+            return new AssignTaskCommand(
+                task.getId(),
+                EngineTaskCommandSorterKt.ORDER_TASK_ASSIGNMENT,
+                CamundaTaskEventType.ASSIGN,
+                assignee);
         }
+        // skip eventing
+        return null;
     }
 }

--- a/digiwf-task/digiwf-polyflow-connector-starter/src/main/java/io/muenchendigital/digiwf/task/listener/CancelableTaskStatusCreateTaskListener.java
+++ b/digiwf-task/digiwf-polyflow-connector-starter/src/main/java/io/muenchendigital/digiwf/task/listener/CancelableTaskStatusCreateTaskListener.java
@@ -23,7 +23,7 @@ public class CancelableTaskStatusCreateTaskListener {
   @Order(TaskEventCollectorService.ORDER - 1001) // be before polyflow
   @EventListener(condition = "#task.eventName.equals('create')")
   public void taskCreated(DelegateTask task) {
-    writer(task).set(TASK_CANCELABLE, hasAttachedErrorBoundaryEvent(task));
+    writer(task).setLocal(TASK_CANCELABLE, hasAttachedErrorBoundaryEvent(task));
   }
 
   /**

--- a/digiwf-task/digiwf-polyflow-connector-starter/src/test/java/io/muenchendigital/digiwf/task/listener/CancelableTaskStatusCreateTaskListenerTest.java
+++ b/digiwf-task/digiwf-polyflow-connector-starter/src/test/java/io/muenchendigital/digiwf/task/listener/CancelableTaskStatusCreateTaskListenerTest.java
@@ -6,6 +6,7 @@ import org.assertj.core.api.Assertions;
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.delegate.DelegateTask;
 import org.camunda.bpm.engine.delegate.TaskListener;
 import org.camunda.bpm.engine.test.Deployment;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import static io.holunda.camunda.bpm.data.CamundaBpmData.reader;
 import static io.muenchendigital.digiwf.task.TaskVariables.TASK_CANCELABLE;
 import static org.camunda.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
+import static org.camunda.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
 
 class CancelableTaskStatusCreateTaskListenerTest {
 
@@ -33,6 +35,7 @@ class CancelableTaskStatusCreateTaskListenerTest {
       .build();
 
   private final RuntimeService runtimeService = extension.getRuntimeService();
+  private final TaskService taskService = extension.getTaskService();
 
 
   @BeforeEach
@@ -48,7 +51,7 @@ class CancelableTaskStatusCreateTaskListenerTest {
     assertThat(instance).isStarted();
     assertThat(instance).isWaitingAt("user_task");
 
-    val cancelable = reader(runtimeService, instance.getId()).get(TASK_CANCELABLE);
+    val cancelable = reader(taskService, task().getId()).getLocal(TASK_CANCELABLE);
     Assertions.assertThat(cancelable).isTrue();
   }
 
@@ -60,7 +63,7 @@ class CancelableTaskStatusCreateTaskListenerTest {
     assertThat(instance).isStarted();
     assertThat(instance).isWaitingAt("user_task");
 
-    val cancelable = reader(runtimeService, instance.getId()).get(TASK_CANCELABLE);
+    val cancelable = reader(taskService, task().getId()).getLocal(TASK_CANCELABLE);
     Assertions.assertThat(cancelable).isTrue();
   }
 
@@ -72,7 +75,7 @@ class CancelableTaskStatusCreateTaskListenerTest {
     assertThat(instance).isStarted();
     assertThat(instance).isWaitingAt("user_task");
 
-    val cancelable = reader(runtimeService, instance.getId()).get(TASK_CANCELABLE);
+    val cancelable = reader(taskService, task().getId()).getLocal(TASK_CANCELABLE);
     Assertions.assertThat(cancelable).isFalse();
   }
 
@@ -84,7 +87,7 @@ class CancelableTaskStatusCreateTaskListenerTest {
     assertThat(instance).isStarted();
     assertThat(instance).isWaitingAt("user_task");
 
-    val cancelable = reader(runtimeService, instance.getId()).get(TASK_CANCELABLE);
+    val cancelable = reader(taskService, task().getId()).getLocal(TASK_CANCELABLE);
     Assertions.assertThat(cancelable).isFalse();
   }
 


### PR DESCRIPTION
**Description**

- Add missing polyflow command creation inside of assign listener.
- Fix storage of cancellation info as LOCAL variables.

**Reference**

![image](https://github.com/it-at-m/digiwf-core/assets/673128/5a7d50e1-57a6-4170-b236-d6e6bad86a57)

