### PR TITLE
#324 workaround camunda rest cannot parse full iso8601 dates

### DIFF
--- a/digiwf-engine/digiwf-engine-service/src/main/java/io/muenchendigital/digiwf/shared/configuration/CamundaJacksonConfiguration.java
+++ b/digiwf-engine/digiwf-engine-service/src/main/java/io/muenchendigital/digiwf/shared/configuration/CamundaJacksonConfiguration.java
@@ -1,0 +1,13 @@
+package io.muenchendigital.digiwf.shared.configuration;
+
+import org.camunda.bpm.engine.rest.mapper.JacksonConfigurator;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CamundaJacksonConfiguration {
+
+    CamundaJacksonConfiguration() {
+        JacksonConfigurator.dateFormatString = "yyyy-MM-dd'T'HH:mm:ss.SSSX";
+    }
+
+}


### PR DESCRIPTION
**Description**

The camunda rest api can only pass a subpart of iso8601 and so dates with colcon in the timezone part can not be parsed. (i.E. working: `2023-05-17T09:02:58.387+0000`, not working: `2023-05-17T09:02:58.387+00:00`)
With this mr the format of the datetime is overwritten to support the full iso8601.
References:
- https://github.com/camunda/camunda-docs-manual/blob/master/content/reference/rest/overview/date-format.md
- https://github.com/camunda/camunda-bpm-platform/blob/master/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/mapper/JacksonConfigurator.java#L37

**Reference**

Issues #324 
