### PR TITLE
Feature/release docker images for macs #234

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,8 +70,8 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_MIRAGON_USERNAME }}
-          password: ${{ secrets.DOCKER_MIRAGON_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_KEY }}
 
       - name: Set Release version env variable
         run: |
@@ -82,7 +82,7 @@ jobs:
         with:
           context: ./digiwf-connector/digiwf-camunda-connector-service
           push: true
-          tags: miragon/digiwf-camunda-connector-service:${{ env.RELEASE_VERSION }},miragon/digiwf-camunda-connector-service:dev
+          tags: itatm/digiwf-camunda-connector-service:${{ env.RELEASE_VERSION }},itatm/digiwf-camunda-connector-service:dev
           platforms: linux/amd64, linux/arm64/v8
 
       - name: Build and push gateway
@@ -90,7 +90,7 @@ jobs:
         with:
           context: ./digiwf-gateway
           push: true
-          tags: miragon/digiwf-gateway:${{ env.RELEASE_VERSION }},miragon/digiwf-gateway:dev
+          tags: itatm/digiwf-gateway:${{ env.RELEASE_VERSION }},itatm/digiwf-gateway:dev
           platforms: linux/amd64, linux/arm64/v8
 
       - name: Build and push cosys
@@ -98,7 +98,7 @@ jobs:
         with:
           context: ./digiwf-integrations/digiwf-cosys-integration/digiwf-cosys-integration-service
           push: true
-          tags: miragon/digiwf-cosys-integration-service:${{ env.RELEASE_VERSION }},miragon/digiwf-cosys-integration-service:dev
+          tags: itatm/digiwf-cosys-integration-service:${{ env.RELEASE_VERSION }},itatm/digiwf-cosys-integration-service:dev
           platforms: linux/amd64, linux/arm64/v8
 
       - name: Build and push email integration
@@ -106,7 +106,7 @@ jobs:
         with:
           context: ./digiwf-integrations/digiwf-email-integration/digiwf-email-integration-service
           push: true
-          tags: miragon/digiwf-email-integration-service:${{ env.RELEASE_VERSION }},miragon/digiwf-email-integration-service:dev
+          tags: itatm/digiwf-email-integration-service:${{ env.RELEASE_VERSION }},itatm/digiwf-email-integration-service:dev
           platforms: linux/amd64, linux/arm64/v8
 
       - name: Build and push alw-integration
@@ -114,7 +114,7 @@ jobs:
         with:
           context: ./digiwf-integrations/digiwf-alw-integration/digiwf-alw-integration-service
           push: true
-          tags: miragon/digiwf-alw-integration-service:${{ env.RELEASE_VERSION }},miragon/digiwf-alw-integration-service:dev
+          tags: itatm/digiwf-alw-integration-service:${{ env.RELEASE_VERSION }},itatm/digiwf-alw-integration-service:dev
           platforms: linux/amd64, linux/arm64/v8
 
       - name: Build and push verification-integration
@@ -122,7 +122,7 @@ jobs:
         with:
           context: ./digiwf-integrations/digiwf-verification-integration/digiwf-verification-integration-service
           push: true
-          tags: miragon/digiwf-verification-integration-service:${{ env.RELEASE_VERSION }},miragon/digiwf-verification-integration-service:dev
+          tags: itatm/digiwf-verification-integration-service:${{ env.RELEASE_VERSION }},itatm/digiwf-verification-integration-service:dev
           platforms: linux/amd64, linux/arm64/v8
 
       - name: Build and push s3-integration
@@ -130,7 +130,7 @@ jobs:
         with:
           context: ./digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-service
           push: true
-          tags: miragon/digiwf-s3-integration-service:${{ env.RELEASE_VERSION }},miragon/digiwf-s3-integration-service:dev
+          tags: itatm/digiwf-s3-integration-service:${{ env.RELEASE_VERSION }},itatm/digiwf-s3-integration-service:dev
           platforms: linux/amd64, linux/arm64/v8
 
       - name: Build and push oss engine
@@ -138,7 +138,7 @@ jobs:
         with:
           context: ./digiwf-engine/digiwf-engine-service
           push: true
-          tags: miragon/digiwf-engine-service-community:${{ env.RELEASE_VERSION }},miragon/digiwf-engine-service-community:dev
+          tags: itatm/digiwf-engine-service-community:${{ env.RELEASE_VERSION }},itatm/digiwf-engine-service-community:dev
           platforms: linux/amd64, linux/arm64/v8
 
       - name: Build and push tasklist backend
@@ -146,7 +146,7 @@ jobs:
         with:
           context: ./digiwf-task/digiwf-tasklist-service
           push: true
-          tags: miragon/digiwf-tasklist-backend-service:${{ env.RELEASE_VERSION }},miragon/digiwf-tasklist-backend-service:dev
+          tags: itatm/digiwf-tasklist-backend-service:${{ env.RELEASE_VERSION }},itatm/digiwf-tasklist-backend-service:dev
           platforms: linux/amd64, linux/arm64/v8
 
   release-services-camunda-ee:
@@ -195,7 +195,7 @@ jobs:
         with:
           context: ./digiwf-engine/digiwf-engine-service
           push: true
-          tags: miragon/digiwf-engine-service:${{ env.RELEASE_VERSION }},miragon/digiwf-engine-service:dev
+          tags: itatm/digiwf-engine-service:${{ env.RELEASE_VERSION }},itatm/digiwf-engine-service:dev
           platforms: linux/amd64, linux/arm64/v8
 
   release-apps:
@@ -246,7 +246,7 @@ jobs:
         with:
           context: ./digiwf-apps/packages/apps/digiwf-tasklist
           push: true
-          tags: miragon/digiwf-tasklist:${{ env.RELEASE_VERSION }},miragon/digiwf-tasklist:dev
+          tags: itatm/digiwf-tasklist:${{ env.RELEASE_VERSION }},itatm/digiwf-tasklist:dev
 
   release-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,6 +83,7 @@ jobs:
           context: ./digiwf-connector/digiwf-camunda-connector-service
           push: true
           tags: itatm/digiwf-camunda-connector-service:${{ env.RELEASE_VERSION }},itatm/digiwf-camunda-connector-service:dev
+          platforms: linux/amd64, linux/arm64/v8
 
       - name: Build and push gateway
         uses: docker/build-push-action@v4
@@ -90,6 +91,7 @@ jobs:
           context: ./digiwf-gateway
           push: true
           tags: itatm/digiwf-gateway:${{ env.RELEASE_VERSION }},itatm/digiwf-gateway:dev
+          platforms: linux/amd64, linux/arm64/v8
 
       - name: Build and push cosys
         uses: docker/build-push-action@v4
@@ -97,6 +99,7 @@ jobs:
           context: ./digiwf-integrations/digiwf-cosys-integration/digiwf-cosys-integration-service
           push: true
           tags: itatm/digiwf-cosys-integration-service:${{ env.RELEASE_VERSION }},itatm/digiwf-cosys-integration-service:dev
+          platforms: linux/amd64, linux/arm64/v8
 
       - name: Build and push email integration
         uses: docker/build-push-action@v4
@@ -104,6 +107,7 @@ jobs:
           context: ./digiwf-integrations/digiwf-email-integration/digiwf-email-integration-service
           push: true
           tags: itatm/digiwf-email-integration-service:${{ env.RELEASE_VERSION }},itatm/digiwf-email-integration-service:dev
+          platforms: linux/amd64, linux/arm64/v8
 
       - name: Build and push alw-integration
         uses: docker/build-push-action@v4
@@ -111,6 +115,7 @@ jobs:
           context: ./digiwf-integrations/digiwf-alw-integration/digiwf-alw-integration-service
           push: true
           tags: itatm/digiwf-alw-integration-service:${{ env.RELEASE_VERSION }},itatm/digiwf-alw-integration-service:dev
+          platforms: linux/amd64, linux/arm64/v8
 
       - name: Build and push verification-integration
         uses: docker/build-push-action@v4
@@ -118,6 +123,7 @@ jobs:
           context: ./digiwf-integrations/digiwf-verification-integration/digiwf-verification-integration-service
           push: true
           tags: itatm/digiwf-verification-integration-service:${{ env.RELEASE_VERSION }},itatm/digiwf-verification-integration-service:dev
+          platforms: linux/amd64, linux/arm64/v8
 
       - name: Build and push s3-integration
         uses: docker/build-push-action@v4
@@ -125,6 +131,7 @@ jobs:
           context: ./digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-service
           push: true
           tags: itatm/digiwf-s3-integration-service:${{ env.RELEASE_VERSION }},itatm/digiwf-s3-integration-service:dev
+          platforms: linux/amd64, linux/arm64/v8
 
       - name: Build and push oss engine
         uses: docker/build-push-action@v4
@@ -132,6 +139,7 @@ jobs:
           context: ./digiwf-engine/digiwf-engine-service
           push: true
           tags: itatm/digiwf-engine-service-community:${{ env.RELEASE_VERSION }},itatm/digiwf-engine-service-community:dev
+          platforms: linux/amd64, linux/arm64/v8
 
       - name: Build and push tasklist backend
         uses: docker/build-push-action@v4
@@ -139,6 +147,7 @@ jobs:
           context: ./digiwf-task/digiwf-tasklist-service
           push: true
           tags: itatm/digiwf-tasklist-backend-service:${{ env.RELEASE_VERSION }},itatm/digiwf-tasklist-backend-service:dev
+          platforms: linux/amd64, linux/arm64/v8
 
   release-services-camunda-ee:
     if: github.event.inputs.services == 'y'
@@ -187,6 +196,7 @@ jobs:
           context: ./digiwf-engine/digiwf-engine-service
           push: true
           tags: itatm/digiwf-engine-service:${{ env.RELEASE_VERSION }},itatm/digiwf-engine-service:dev
+          platforms: linux/amd64, linux/arm64/v8
 
   release-apps:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,8 +70,8 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_KEY }}
+          username: ${{ secrets.DOCKER_MIRAGON_USERNAME }}
+          password: ${{ secrets.DOCKER_MIRAGON_PASSWORD }}
 
       - name: Set Release version env variable
         run: |
@@ -82,7 +82,7 @@ jobs:
         with:
           context: ./digiwf-connector/digiwf-camunda-connector-service
           push: true
-          tags: itatm/digiwf-camunda-connector-service:${{ env.RELEASE_VERSION }},itatm/digiwf-camunda-connector-service:dev
+          tags: miragon/digiwf-camunda-connector-service:${{ env.RELEASE_VERSION }},miragon/digiwf-camunda-connector-service:dev
           platforms: linux/amd64, linux/arm64/v8
 
       - name: Build and push gateway
@@ -90,7 +90,7 @@ jobs:
         with:
           context: ./digiwf-gateway
           push: true
-          tags: itatm/digiwf-gateway:${{ env.RELEASE_VERSION }},itatm/digiwf-gateway:dev
+          tags: miragon/digiwf-gateway:${{ env.RELEASE_VERSION }},miragon/digiwf-gateway:dev
           platforms: linux/amd64, linux/arm64/v8
 
       - name: Build and push cosys
@@ -98,7 +98,7 @@ jobs:
         with:
           context: ./digiwf-integrations/digiwf-cosys-integration/digiwf-cosys-integration-service
           push: true
-          tags: itatm/digiwf-cosys-integration-service:${{ env.RELEASE_VERSION }},itatm/digiwf-cosys-integration-service:dev
+          tags: miragon/digiwf-cosys-integration-service:${{ env.RELEASE_VERSION }},miragon/digiwf-cosys-integration-service:dev
           platforms: linux/amd64, linux/arm64/v8
 
       - name: Build and push email integration
@@ -106,7 +106,7 @@ jobs:
         with:
           context: ./digiwf-integrations/digiwf-email-integration/digiwf-email-integration-service
           push: true
-          tags: itatm/digiwf-email-integration-service:${{ env.RELEASE_VERSION }},itatm/digiwf-email-integration-service:dev
+          tags: miragon/digiwf-email-integration-service:${{ env.RELEASE_VERSION }},miragon/digiwf-email-integration-service:dev
           platforms: linux/amd64, linux/arm64/v8
 
       - name: Build and push alw-integration
@@ -114,7 +114,7 @@ jobs:
         with:
           context: ./digiwf-integrations/digiwf-alw-integration/digiwf-alw-integration-service
           push: true
-          tags: itatm/digiwf-alw-integration-service:${{ env.RELEASE_VERSION }},itatm/digiwf-alw-integration-service:dev
+          tags: miragon/digiwf-alw-integration-service:${{ env.RELEASE_VERSION }},miragon/digiwf-alw-integration-service:dev
           platforms: linux/amd64, linux/arm64/v8
 
       - name: Build and push verification-integration
@@ -122,7 +122,7 @@ jobs:
         with:
           context: ./digiwf-integrations/digiwf-verification-integration/digiwf-verification-integration-service
           push: true
-          tags: itatm/digiwf-verification-integration-service:${{ env.RELEASE_VERSION }},itatm/digiwf-verification-integration-service:dev
+          tags: miragon/digiwf-verification-integration-service:${{ env.RELEASE_VERSION }},miragon/digiwf-verification-integration-service:dev
           platforms: linux/amd64, linux/arm64/v8
 
       - name: Build and push s3-integration
@@ -130,7 +130,7 @@ jobs:
         with:
           context: ./digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-service
           push: true
-          tags: itatm/digiwf-s3-integration-service:${{ env.RELEASE_VERSION }},itatm/digiwf-s3-integration-service:dev
+          tags: miragon/digiwf-s3-integration-service:${{ env.RELEASE_VERSION }},miragon/digiwf-s3-integration-service:dev
           platforms: linux/amd64, linux/arm64/v8
 
       - name: Build and push oss engine
@@ -138,7 +138,7 @@ jobs:
         with:
           context: ./digiwf-engine/digiwf-engine-service
           push: true
-          tags: itatm/digiwf-engine-service-community:${{ env.RELEASE_VERSION }},itatm/digiwf-engine-service-community:dev
+          tags: miragon/digiwf-engine-service-community:${{ env.RELEASE_VERSION }},miragon/digiwf-engine-service-community:dev
           platforms: linux/amd64, linux/arm64/v8
 
       - name: Build and push tasklist backend
@@ -146,7 +146,7 @@ jobs:
         with:
           context: ./digiwf-task/digiwf-tasklist-service
           push: true
-          tags: itatm/digiwf-tasklist-backend-service:${{ env.RELEASE_VERSION }},itatm/digiwf-tasklist-backend-service:dev
+          tags: miragon/digiwf-tasklist-backend-service:${{ env.RELEASE_VERSION }},miragon/digiwf-tasklist-backend-service:dev
           platforms: linux/amd64, linux/arm64/v8
 
   release-services-camunda-ee:
@@ -195,7 +195,7 @@ jobs:
         with:
           context: ./digiwf-engine/digiwf-engine-service
           push: true
-          tags: itatm/digiwf-engine-service:${{ env.RELEASE_VERSION }},itatm/digiwf-engine-service:dev
+          tags: miragon/digiwf-engine-service:${{ env.RELEASE_VERSION }},miragon/digiwf-engine-service:dev
           platforms: linux/amd64, linux/arm64/v8
 
   release-apps:
@@ -246,7 +246,7 @@ jobs:
         with:
           context: ./digiwf-apps/packages/apps/digiwf-tasklist
           push: true
-          tags: itatm/digiwf-tasklist:${{ env.RELEASE_VERSION }},itatm/digiwf-tasklist:dev
+          tags: miragon/digiwf-tasklist:${{ env.RELEASE_VERSION }},miragon/digiwf-tasklist:dev
 
   release-docs:
     runs-on: ubuntu-latest

--- a/digiwf-connector/digiwf-camunda-connector-service/Dockerfile
+++ b/digiwf-connector/digiwf-camunda-connector-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/openjdk-11:latest
+FROM amazoncorretto:11
 
 EXPOSE 8080
 

--- a/digiwf-engine/digiwf-engine-service/Dockerfile
+++ b/digiwf-engine/digiwf-engine-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/openjdk-11:latest
+FROM amazoncorretto:11
 
 EXPOSE 8080
 

--- a/digiwf-gateway/Dockerfile
+++ b/digiwf-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/openjdk-11:latest
+FROM amazoncorretto:11
 
 EXPOSE 8080
 

--- a/digiwf-integrations/digiwf-alw-integration/digiwf-alw-integration-service/Dockerfile
+++ b/digiwf-integrations/digiwf-alw-integration/digiwf-alw-integration-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/openjdk-11:latest
+FROM amazoncorretto:11
 
 EXPOSE 8080
 

--- a/digiwf-integrations/digiwf-cosys-integration/digiwf-cosys-integration-service/Dockerfile
+++ b/digiwf-integrations/digiwf-cosys-integration/digiwf-cosys-integration-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/openjdk-11:latest
+FROM amazoncorretto:11
 
 EXPOSE 8080
 

--- a/digiwf-integrations/digiwf-email-integration/digiwf-email-integration-service/Dockerfile
+++ b/digiwf-integrations/digiwf-email-integration/digiwf-email-integration-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/openjdk-11:latest
+FROM amazoncorretto:11
 
 EXPOSE 8080
 

--- a/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-service/Dockerfile
+++ b/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/openjdk-11:latest
+FROM amazoncorretto:11
 
 EXPOSE 8080
 

--- a/digiwf-integrations/digiwf-verification-integration/digiwf-verification-integration-service/Dockerfile
+++ b/digiwf-integrations/digiwf-verification-integration/digiwf-verification-integration-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/openjdk-11:latest
+FROM amazoncorretto:11
 
 EXPOSE 8080
 

--- a/digiwf-task/digiwf-tasklist-service/Dockerfile
+++ b/digiwf-task/digiwf-tasklist-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/openjdk-11:latest
+FROM amazoncorretto:11
 
 EXPOSE 8080
 


### PR DESCRIPTION
**Description**

The current digiwf docker images do not run on arm processors. Therefore, I changed the docker base images to amazoncorretto and added the arm architecture to the release pipeline.

**Reference**

Issues #234 
