### PR TITLE
Docs S3 Config update

### DIFF
--- a/docs/src/modeling/processes/config/README.md
+++ b/docs/src/modeling/processes/config/README.md
@@ -41,11 +41,11 @@ wie Notepad++ oder Visual Studio Code zurückzugreifen.
     },
     {
       "key": "app_file_s3_async_config",
-      "value": "dwf-s3-demo"
+      "value": "my-s3-topic"
     },
     {
       "key": "app_file_s3_sync_config",
-      "value": "http://digiwf-document-storage-service:8080"
+      "value": "http://my-document-storage-service:8080"
     },
       {
       "key": "app_instance_schema_key",
@@ -78,9 +78,11 @@ In den configs können zudem DigiWF-spezifische Einstellungen angegeben werden:
   die nicht im Formular enthalten sind. Stattdessen werden die Daten lediglich gefiltert und nicht in der Engine
   persistiert.
 - **app_file_s3_async_config:** Wird die Einstellung gesetzt, dann wird der Wert als Konfiguration für den S3-Service
-  verwendet. Dabei handelt es sich um das Topic für den verwendeten S3-Service.
+  verwendet. Dabei handelt es sich um das Topic für den verwendeten S3-Service. Die Konfig wird von der Plattform 
+  autom. gesetzt und nur benötigt, wenn man es überschreiben möchte.
 - **app_file_s3_sync_config:** Wird die Einstellung gesetzt, dann wird der Wert als Konfiguration für den S3-Service
-  verwendet. Dabei handelt es sich um die URL des verwendeten S3-Service.
+  verwendet. Dabei handelt es sich um die URL des verwendeten S3-Service. Die Konfig wird von der Plattform 
+  autom. gesetzt und nur benötigt, wenn man es überschreiben möchte.
 - **app_instance_schema_key:** Das Schema, das in der Prozessinstanzübersicht verwendet werden soll, um Daten
   anzuzeigen.
 - **app_instance_file_paths_readonly:** Die Dateipfade,die in der Prozessinstanzübersicht gelesen werden können

--- a/docs/src/modeling/processes/config/README.md
+++ b/docs/src/modeling/processes/config/README.md
@@ -82,7 +82,7 @@ In den configs können zudem DigiWF-spezifische Einstellungen angegeben werden:
   autom. gesetzt und nur benötigt, wenn ein eigener S3-Service für die Ausführung des Prozesses verwendet werden soll.
 - **app_file_s3_sync_config:** Wird die Einstellung gesetzt, dann wird der Wert als Konfiguration für den S3-Service
   verwendet. Dabei handelt es sich um die URL des verwendeten S3-Service. Die Konfig wird von der Plattform 
-  autom. gesetzt und nur benötigt, wenn man es überschreiben möchte.
+  autom. gesetzt und nur benötigt, wenn ein eigener S3-Service für die Ausführung des Prozesses verwendet werden soll.
 - **app_instance_schema_key:** Das Schema, das in der Prozessinstanzübersicht verwendet werden soll, um Daten
   anzuzeigen.
 - **app_instance_file_paths_readonly:** Die Dateipfade,die in der Prozessinstanzübersicht gelesen werden können

--- a/docs/src/modeling/processes/config/README.md
+++ b/docs/src/modeling/processes/config/README.md
@@ -79,7 +79,7 @@ In den configs können zudem DigiWF-spezifische Einstellungen angegeben werden:
   persistiert.
 - **app_file_s3_async_config:** Wird die Einstellung gesetzt, dann wird der Wert als Konfiguration für den S3-Service
   verwendet. Dabei handelt es sich um das Topic für den verwendeten S3-Service. Die Konfig wird von der Plattform 
-  autom. gesetzt und nur benötigt, wenn man es überschreiben möchte.
+  autom. gesetzt und nur benötigt, wenn ein eigener S3-Service für die Ausführung des Prozesses verwendet werden soll.
 - **app_file_s3_sync_config:** Wird die Einstellung gesetzt, dann wird der Wert als Konfiguration für den S3-Service
   verwendet. Dabei handelt es sich um die URL des verwendeten S3-Service. Die Konfig wird von der Plattform 
   autom. gesetzt und nur benötigt, wenn man es überschreiben möchte.


### PR DESCRIPTION
**Description**

Dokumentation, dass die S3 Config nur benötigt wird zum Überschreiben der Defaults

**Reference**

[Internal Incident](https://git.muenchen.de/digitalisierung/digiwf-support/-/issues/308)
