### PR TITLE
#701: remove unnecessary input listener for native input element

### DIFF
--- a/digiwf-apps/packages/apps/digiwf-tasklist/src/components/schema/VMultiUserInput.vue
+++ b/digiwf-apps/packages/apps/digiwf-tasklist/src/components/schema/VMultiUserInput.vue
@@ -140,7 +140,6 @@ export default class VMultiUserInput extends Vue {
   schema: string | undefined;
 
   input(value: string[]): any {
-    console.log("input: ", value);
     return this.on.input(value);
   }
 

--- a/digiwf-apps/packages/apps/digiwf-tasklist/src/components/schema/VMultiUserInput.vue
+++ b/digiwf-apps/packages/apps/digiwf-tasklist/src/components/schema/VMultiUserInput.vue
@@ -21,7 +21,6 @@
       placeholder="Benutzer suchen..."
       return-object
       multiple
-      @input="input"
       @change="change"
     >
       <template
@@ -140,7 +139,8 @@ export default class VMultiUserInput extends Vue {
   @Prop()
   schema: string | undefined;
 
-  input(value: any): any {
+  input(value: string[]): any {
+    console.log("input: ", value);
     return this.on.input(value);
   }
 
@@ -240,7 +240,9 @@ export default class VMultiUserInput extends Vue {
   }
 
   change(): void {
-    let selectedLhmObjectIds = this.selectedUsers.map(a => a.lhmObjectId);
+    let selectedLhmObjectIds = this.selectedUsers
+      .map(a => a.lhmObjectId)
+      .filter((it): it is string => !!it);
     this.input(selectedLhmObjectIds);
   }
 


### PR DESCRIPTION
### Description

Bugfix für #701 

Fehler war, dass noch auf das native input event gehört wurde und durch die in der Klasse definierte input Funktion gehandelt wurde. Das input event von der Komponente liefert aber das Objekt anstelle der lhmObjectId (wie die onChange Funktion der Klasse). Deswegen trat wurde auch ein Event mit dem vollständigen Nutzerobjekt getriggert. 

Warum das nur in dem Prozess aufgetreten ist, verstehe ich noch nicht.   


### Reference

Issues: #701 

### Check-List

- [ ] Documentation created
- [ ] Environments configured
