### PR TITLE
chore: enable dependabot for github actions and docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     # Workflow files stored in the
     # default location of `.github/workflows`
     directory: "/"
+    open-pull-requests-limit: 20
     schedule:
       interval: "daily"
     labels:
@@ -18,6 +19,7 @@ updates:
       - "Technical Dept"
   - package-ecosystem: npm
     directory: "/docs"
+    open-pull-requests-limit: 20
     target-branch: "dev"
     labels:
       - "Technical Dept"


### PR DESCRIPTION
### Description

Enable dependabot for github actions and docs

### Reference

Issues: ###

### Check-List

- [ ] Documentation created
- [ ] Environments configured
