### PR TITLE
gateway csrf return to spring 5.8 default

### DIFF
--- a/digiwf-gateway/src/main/java/de/muenchen/oss/digiwf/gateway/configuration/SecurityConfiguration.java
+++ b/digiwf-gateway/src/main/java/de/muenchen/oss/digiwf/gateway/configuration/SecurityConfiguration.java
@@ -16,6 +16,7 @@ import org.springframework.security.web.server.WebFilterExchange;
 import org.springframework.security.web.server.authentication.RedirectServerAuthenticationSuccessHandler;
 import org.springframework.security.web.server.authentication.logout.HttpStatusReturningServerLogoutSuccessHandler;
 import org.springframework.security.web.server.csrf.CookieServerCsrfTokenRepository;
+import org.springframework.security.web.server.csrf.ServerCsrfTokenRequestAttributeHandler;
 import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers;
 import reactor.core.publisher.Mono;
 
@@ -60,6 +61,12 @@ public class SecurityConfiguration {
         .cors(corsSpec -> {
         })
         .csrf(csrfSpec -> {
+          /*
+           * Default config before spring security 6.0.
+           * Is vulnerable to BREACH attack.
+           * https://docs.spring.io/spring-security/reference/reactive/exploits/csrf.html#webflux-csrf-configure-request-handler
+           */
+          csrfSpec.csrfTokenRequestHandler(new ServerCsrfTokenRequestAttributeHandler());
           /*
            * The necessary subscription for csrf token attachment to {@link ServerHttpResponse}
            * is done in class {@link CsrfTokenAppendingHelperFilter}.


### PR DESCRIPTION
### Description

Short description or comments

### Reference

Issues: closes #1012

### Check-List

- [ ] All Acceptance criteria of user story are met
- [ ] JUnit tests are written (60% CodeCov)
- [ ] [Internal Review]([https://github.com/it-at-m/digiwf-core/blob/dev/CHANGELOG.md](https://confluence.muenchen.de/display/MPdZ/Review+-+DigiWF)) is maintained
- [ ] Documentations [external](https://github.com/it-at-m/digiwf-core/tree/dev/docs) and [internal](https://wiki.muenchen.de/betriebshandbuch/index.php?title=DigiWF&sfr=betriebshandbuch) are completed
- [ ] Smoketest successful (Manual E2E-Test depending on Change) 
- [ ] No Branch waste left
- [ ] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
- [ ] Openshift environments are prepared (Secrets, etc.) and release-issue is maintained
