### PR TITLE
getFrontendUrl-Public

### DIFF
--- a/digiwf-engine/digiwf-engine-service/src/main/java/de/muenchen/oss/digiwf/engine/basis/process/DigitalWFFunctions.java
+++ b/digiwf-engine/digiwf-engine-service/src/main/java/de/muenchen/oss/digiwf/engine/basis/process/DigitalWFFunctions.java
@@ -39,7 +39,7 @@ public class DigitalWFFunctions {
         return this.getFrontendUrl() + "#/opengrouptask";
     }
 
-    private String getFrontendUrl() {
+    public String getFrontendUrl() {
         return this.properties.getFrontendUrl().endsWith("/") ? this.properties.getFrontendUrl() : this.properties.getFrontendUrl() + "/";
     }
 


### PR DESCRIPTION
### Description

Public setzen von `getFrontendUrl`, da diese Funktion auch in der Doku angeboten wird.

### Reference

Issues: closes #1002 

### Check-List

- [x] All Acceptance criteria of user story are met
- [ ] JUnit tests are written (60% CodeCov)
- [ ] [Internal Review]([https://github.com/it-at-m/digiwf-core/blob/dev/CHANGELOG.md](https://confluence.muenchen.de/display/MPdZ/Review+-+DigiWF)) is maintained
- [x] Documentations [external](https://github.com/it-at-m/digiwf-core/tree/dev/docs) and [internal](https://wiki.muenchen.de/betriebshandbuch/index.php?title=DigiWF&sfr=betriebshandbuch) are completed
- [ ] Smoketest successful (Manual E2E-Test depending on Change) 
- [x] No Branch waste left
- [x] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
- [x] Openshift environments are prepared (Secrets, etc.) and release-issue is maintained
