### PR TITLE
gateway add oauth client routes

### DIFF
--- a/digiwf-gateway/pom.xml
+++ b/digiwf-gateway/pom.xml
@@ -63,6 +63,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-oauth2-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
 
         <!-- hazelcast -->
         <dependency>

--- a/digiwf-gateway/src/main/java/de/muenchen/oss/digiwf/gateway/configuration/SecurityConfiguration.java
+++ b/digiwf-gateway/src/main/java/de/muenchen/oss/digiwf/gateway/configuration/SecurityConfiguration.java
@@ -8,7 +8,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.server.SecurityWebFilterChain;
@@ -38,6 +40,21 @@ public class SecurityConfiguration {
   private long springSessionTimeoutSeconds;
 
   @Bean
+  @Order(0)
+  public SecurityWebFilterChain clientAccessFilterChain(ServerHttpSecurity http) {
+    http
+        .securityMatcher(ServerWebExchangeMatchers.pathMatchers("/clients/**"))
+        .authorizeExchange(authorizeExchangeSpec -> {
+          authorizeExchangeSpec.anyExchange().authenticated();
+        })
+        .oauth2ResourceServer(oauth2 ->
+          oauth2.jwt(Customizer.withDefaults())
+        );
+    return http.build();
+  }
+
+  @Bean
+  @Order(1)
   public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
     http
         .logout(logoutSpec -> {

--- a/digiwf-gateway/src/main/resources/application-local.yml
+++ b/digiwf-gateway/src/main/resources/application-local.yml
@@ -25,12 +25,28 @@ spring:
           predicates:
             - Path=/camunda/**
 
+        - id: backend-client
+          uri: http://${ENGINE_SERVER_HOST:localhost}:${ENGINE_SERVER_PORT}/
+          predicates:
+            - Path=/clients/digitalwf-backend-service/**
+          filters:
+            - RewritePath=/clients/digitalwf-backend-service/(?<urlsegments>.*), /$\{urlsegments}
+            - RemoveResponseHeader=WWW-Authenticate
+
         - id: tasklist
           uri: http://${TASKSERVICE_SERVER_HOST:localhost}:${TASKSERVICE_SERVER_PORT}/
           predicates:
             - Path=/api/digitalwf-tasklist-service/rest/**
           filters:
             - RewritePath=/api/digitalwf-tasklist-service/(?<urlsegments>.*), /$\{urlsegments}
+            - RemoveResponseHeader=WWW-Authenticate
+
+        - id: tasklist-client
+          uri: http://${TASKSERVICE_SERVER_HOST:localhost}:${TASKSERVICE_SERVER_PORT}/
+          predicates:
+            - Path=/clients/digitalwf-tasklist-service/**
+          filters:
+            - RewritePath=/clients/digitalwf-tasklist-service/(?<urlsegments>.*), /$\{urlsegments}
             - RemoveResponseHeader=WWW-Authenticate
 
         - id: frontend

--- a/digiwf-gateway/src/main/resources/application.yml
+++ b/digiwf-gateway/src/main/resources/application.yml
@@ -18,6 +18,9 @@ spring:
         instrumentation-type: decorate_on_each  # https://github.com/spring-cloud/spring-cloud-gateway/pull/2106
   security:
     oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${SSO_ISSUER_URL}
       client:
         provider:
           keycloak:

--- a/digiwf-gateway/src/main/resources/application.yml
+++ b/digiwf-gateway/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: ${SSO_ISSUER_URL}
+          issuer-uri: ${SSO_ISSUER_URL:sso.muenchen.de}
       client:
         provider:
           keycloak:


### PR DESCRIPTION
### Description

Add support for `/clients/**` routes which support authentication directly via oauth token.

### Reference

Was done for issue: #1024 

### Check-List

- [ ] All Acceptance criteria of user story are met
- [ ] JUnit tests are written (60% CodeCov)
- [ ] [Internal Review]([https://github.com/it-at-m/digiwf-core/blob/dev/CHANGELOG.md](https://confluence.muenchen.de/display/MPdZ/Review+-+DigiWF)) is maintained
- [ ] Documentations [external](https://github.com/it-at-m/digiwf-core/tree/dev/docs) and [internal](https://wiki.muenchen.de/betriebshandbuch/index.php?title=DigiWF&sfr=betriebshandbuch) are completed
- [ ] Smoketest successful (Manual E2E-Test depending on Change) 
- [ ] No Branch waste left
- [ ] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
- [ ] Openshift environments are prepared (Secrets, etc.) and release-issue is maintained
