### PR TITLE
fix entity scan and missing polyflow-kafka profile activation

### DIFF
--- a/digiwf-engine/digiwf-engine-service/src/main/java/de/muenchen/oss/digiwf/shared/configuration/JpaEngineConfiguration.java
+++ b/digiwf-engine/digiwf-engine-service/src/main/java/de/muenchen/oss/digiwf/shared/configuration/JpaEngineConfiguration.java
@@ -1,0 +1,14 @@
+package de.muenchen.oss.digiwf.shared.configuration;
+
+import de.muenchen.oss.digiwf.EngineServiceApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EntityScan(
+    basePackageClasses = {
+        EngineServiceApplication.class
+    }
+)
+public class JpaEngineConfiguration {
+}

--- a/digiwf-engine/digiwf-engine-service/src/main/resources/application.yml
+++ b/digiwf-engine/digiwf-engine-service/src/main/resources/application.yml
@@ -112,6 +112,8 @@ spring:
             client-id: ${SSO_S3_CLIENT_ID}
             client-secret: ${SSO_S3_CLIENT_SECRET}
             scope: email, profile, openid  # needed for userInfo endpoint
+  profiles:
+    include: polyflow-kafka
 
 springdoc:
   packagesToScan: de.muenchen.oss.digiwf

--- a/digiwf-engine/digiwf-engine-service/src/main/resources/db/migration/postgresql/V12__axon_framework_4.9.sql
+++ b/digiwf-engine/digiwf-engine-service/src/main/resources/db/migration/postgresql/V12__axon_framework_4.9.sql
@@ -1,3 +1,3 @@
 DROP SEQUENCE hibernate_sequence;
-CREATE SEQUENCE association_value_entry_seq START WITH 1 INCREMENT BY 50;
-CREATE SEQUENCE domain_event_entry_seq START WITH 1 INCREMENT BY 50;
+CREATE SEQUENCE association_value_entry_seq START WITH 1000000 INCREMENT BY 50;
+CREATE SEQUENCE domain_event_entry_seq START WITH 1000000 INCREMENT BY 50;

--- a/digiwf-engine/digiwf-engine-service/src/test/resources/application-test.yml
+++ b/digiwf-engine/digiwf-engine-service/src/test/resources/application-test.yml
@@ -19,6 +19,7 @@ spring:
   test:
     database:
       replace: NONE
+
 logging:
   level:
     root: info

--- a/digiwf-task/digiwf-polyflow-connector-starter/src/main/java/de/muenchen/oss/digiwf/task/PolyflowConnectorAutoConfiguration.java
+++ b/digiwf-task/digiwf-polyflow-connector-starter/src/main/java/de/muenchen/oss/digiwf/task/PolyflowConnectorAutoConfiguration.java
@@ -10,13 +10,18 @@ import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.axonframework.common.jpa.EntityManagerProvider;
 import org.axonframework.common.transaction.TransactionManager;
+import org.axonframework.eventhandling.deadletter.jpa.DeadLetterEntry;
+import org.axonframework.eventhandling.tokenstore.jpa.TokenEntry;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
+import org.axonframework.eventsourcing.eventstore.jpa.DomainEventEntry;
 import org.axonframework.eventsourcing.eventstore.jpa.JpaEventStorageEngine;
+import org.axonframework.modelling.saga.repository.jpa.SagaEntry;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.springboot.autoconfig.AxonAutoConfiguration;
 import org.axonframework.springboot.autoconfig.ObjectMapperAutoConfiguration;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -39,6 +44,14 @@ import org.springframework.context.annotation.Configuration;
 })
 @EnableConfigurationProperties(
     TaskManagementProperties.class
+)
+@EntityScan(
+    basePackageClasses = {
+        DomainEventEntry.class,
+        SagaEntry.class,
+        TokenEntry.class,
+        DeadLetterEntry.class
+    }
 )
 @Slf4j
 public class PolyflowConnectorAutoConfiguration {
@@ -90,6 +103,7 @@ public class PolyflowConnectorAutoConfiguration {
                 .entityManagerProvider(entityManagerProvider)
                 .transactionManager(transactionManager)
                 .eventSerializer(eventSerializer)
+                .snapshotSerializer(eventSerializer)
                 .build();
     }
 }


### PR DESCRIPTION
### Description

- fix entity scan 
- :zap: missing `polyflow-kafka` profile activation

## Details

After removal of `BeanPostProcessor` in `polyflow-conector` the default activation of `polyflow-kafka` spring profile was gone. Now it is included as a default to the engine profiles via application.yml in the engine service.