### PR TITLE
chore: fix docs build

### DIFF
--- a/.github/workflows/workflow-release-docs.yaml
+++ b/.github/workflows/workflow-release-docs.yaml
@@ -4,9 +4,6 @@ on:
   workflow_call:
   workflow_dispatch:
 
-env:
-  NODE_OPTIONS: '--openssl-legacy-provider'
-
 jobs:
   release-docs:
     runs-on: ubuntu-latest
@@ -17,13 +14,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '14'
+          node-version: '18'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
           cache-dependency-path: "./docs/package-lock.json"
       - run: npm install
-#      - run: npm run build
-      - run: npx vuepress build src
+      - run: npm run build
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/workflow-release-docs.yaml
+++ b/.github/workflows/workflow-release-docs.yaml
@@ -22,7 +22,8 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache-dependency-path: "./docs/package-lock.json"
       - run: npm install
-      - run: npm run build
+#      - run: npm run build
+      - run: export NODE_OPTIONS=--openssl-legacy-provider && npx vuepress build src
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/workflow-release-docs.yaml
+++ b/.github/workflows/workflow-release-docs.yaml
@@ -17,13 +17,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '14'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
           cache-dependency-path: "./docs/package-lock.json"
       - run: npm install
 #      - run: npm run build
-      - run: export NODE_OPTIONS=--openssl-legacy-provider && npx vuepress build src
+      - run: npx vuepress build src
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,8 +4,8 @@
   "main": "index.js",
   "repository": "https://github.com/it-at-m/digiwf-core.git/digiwf",
   "scripts": {
-    "dev": "cross-env NODE_OPTIONS=--openssl-legacy-provider && vuepress dev src",
-    "build": "cross-env NODE_OPTIONS=--openssl-legacy-provider && vuepress build src"
+    "dev": "cross-env NODE_OPTIONS=--openssl-legacy-provider vuepress dev src",
+    "build": "cross-env NODE_OPTIONS=--openssl-legacy-provider vuepress build src"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
### Description

The docs release pipeline failed with:

```
/home/runner/runners/2.311.0/externals/node16/bin/node: --openssl-legacy-provider is not allowed in NODE_OPTIONS
```

We should either user cross-env or set the env variable manually not both

### Reference

Issues: closes #xxx

### Check-List

- [ ] All Acceptance criteria of user story are met
- [ ] JUnit tests are written (60% CodeCov)
- [ ] [Internal Review]([https://github.com/it-at-m/digiwf-core/blob/dev/CHANGELOG.md](https://confluence.muenchen.de/display/MPdZ/Review+-+DigiWF)) is maintained
- [ ] Documentations [external](https://github.com/it-at-m/digiwf-core/tree/dev/docs) and [internal](https://wiki.muenchen.de/betriebshandbuch/index.php?title=DigiWF&sfr=betriebshandbuch) are completed
- [ ] Smoketest successful (Manual E2E-Test depending on Change) 
- [ ] No Branch waste left
- [ ] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
- [ ] Openshift environments are prepared (Secrets, etc.) and release-issue is maintained
