### PR TITLE
gateway custom csrf request handler

### DIFF
--- a/digiwf-gateway/src/main/java/de/muenchen/oss/digiwf/gateway/configuration/SecurityConfiguration.java
+++ b/digiwf-gateway/src/main/java/de/muenchen/oss/digiwf/gateway/configuration/SecurityConfiguration.java
@@ -18,7 +18,6 @@ import org.springframework.security.web.server.WebFilterExchange;
 import org.springframework.security.web.server.authentication.RedirectServerAuthenticationSuccessHandler;
 import org.springframework.security.web.server.authentication.logout.HttpStatusReturningServerLogoutSuccessHandler;
 import org.springframework.security.web.server.csrf.CookieServerCsrfTokenRepository;
-import org.springframework.security.web.server.csrf.ServerCsrfTokenRequestAttributeHandler;
 import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers;
 import reactor.core.publisher.Mono;
 
@@ -79,11 +78,10 @@ public class SecurityConfiguration {
         })
         .csrf(csrfSpec -> {
           /*
-           * Default config before spring security 6.0.
-           * Is vulnerable to BREACH attack.
-           * https://docs.spring.io/spring-security/reference/reactive/exploits/csrf.html#webflux-csrf-configure-request-handler
+           * Custom csrf request handler for spa and BREACH attack protection.
+           * https://docs.spring.io/spring-security/reference/6.1-SNAPSHOT/servlet/exploits/csrf.html#csrf-integration-javascript-spa
            */
-          csrfSpec.csrfTokenRequestHandler(new ServerCsrfTokenRequestAttributeHandler());
+          csrfSpec.csrfTokenRequestHandler(new SpaServerCsrfTokenRequestHandler());
           /*
            * The necessary subscription for csrf token attachment to {@link ServerHttpResponse}
            * is done in class {@link CsrfTokenAppendingHelperFilter}.

--- a/digiwf-gateway/src/main/java/de/muenchen/oss/digiwf/gateway/configuration/SpaServerCsrfTokenRequestHandler.java
+++ b/digiwf-gateway/src/main/java/de/muenchen/oss/digiwf/gateway/configuration/SpaServerCsrfTokenRequestHandler.java
@@ -1,0 +1,41 @@
+package de.muenchen.oss.digiwf.gateway.configuration;
+
+import org.springframework.security.web.server.csrf.CsrfToken;
+import org.springframework.security.web.server.csrf.ServerCsrfTokenRequestAttributeHandler;
+import org.springframework.security.web.server.csrf.ServerCsrfTokenRequestHandler;
+import org.springframework.security.web.server.csrf.XorServerCsrfTokenRequestAttributeHandler;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+public class SpaServerCsrfTokenRequestHandler extends ServerCsrfTokenRequestAttributeHandler {
+    private final ServerCsrfTokenRequestHandler delegate = new XorServerCsrfTokenRequestAttributeHandler();
+
+    @Override
+    public void handle(ServerWebExchange exchange, Mono<CsrfToken> csrfToken) {
+        /*
+         * Always use XorCsrfTokenRequestAttributeHandler to provide BREACH protection of
+         * the CsrfToken when it is rendered in the response body.
+         */
+        this.delegate.handle(exchange, csrfToken);
+    }
+
+    @Override
+    public Mono<String> resolveCsrfTokenValue(ServerWebExchange exchange, CsrfToken csrfToken) {
+        /*
+         * If the request contains a request header, use CsrfTokenRequestAttributeHandler
+         * to resolve the CsrfToken. This applies when a single-page application includes
+         * the header value automatically, which was obtained via a cookie containing the
+         * raw CsrfToken.
+         */
+        if (exchange.getRequest().getHeaders().containsKey(csrfToken.getHeaderName())) {
+            return super.resolveCsrfTokenValue(exchange, csrfToken);
+        }
+        /*
+         * In all other cases (e.g. if the request contains a request parameter), use
+         * XorCsrfTokenRequestAttributeHandler to resolve the CsrfToken. This applies
+         * when a server-side rendered form includes the _csrf request parameter as a
+         * hidden input.
+         */
+        return this.delegate.resolveCsrfTokenValue(exchange, csrfToken);
+    }
+}


### PR DESCRIPTION
### Description

Gateway custom csrf request handler to protect against breach attacks.

### Reference

Issues: closes #1014

### Check-List

- [ ] All Acceptance criteria of user story are met
- [ ] JUnit tests are written (60% CodeCov)
- [ ] [Internal Review]([https://github.com/it-at-m/digiwf-core/blob/dev/CHANGELOG.md](https://confluence.muenchen.de/display/MPdZ/Review+-+DigiWF)) is maintained
- [ ] Documentations [external](https://github.com/it-at-m/digiwf-core/tree/dev/docs) and [internal](https://wiki.muenchen.de/betriebshandbuch/index.php?title=DigiWF&sfr=betriebshandbuch) are completed
- [ ] Smoketest successful (Manual E2E-Test depending on Change) 
- [ ] No Branch waste left
- [ ] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
- [ ] Openshift environments are prepared (Secrets, etc.) and release-issue is maintained
