### PR TITLE
revert compiler warning fixes for builder

### DIFF
--- a/digiwf-engine/digiwf-engine-service/src/main/java/de/muenchen/oss/digiwf/legacy/dms/muc/domain/model/Dokument.java
+++ b/digiwf-engine/digiwf-engine-service/src/main/java/de/muenchen/oss/digiwf/legacy/dms/muc/domain/model/Dokument.java
@@ -48,7 +48,6 @@ public class Dokument {
     /**
      * Liste der enthaltenen Schriftstücke
      */
-    @Builder.Default
     private List<Schriftstueck> schriftstuecke = new ArrayList<>();
 
     public Dokument(final NeuesDokument neuesDokument, final String coo, final List<Schriftstueck> schriftstuecke) {

--- a/digiwf-engine/digiwf-engine-service/src/main/java/de/muenchen/oss/digiwf/legacy/dms/muc/domain/model/Vorgang.java
+++ b/digiwf-engine/digiwf-engine-service/src/main/java/de/muenchen/oss/digiwf/legacy/dms/muc/domain/model/Vorgang.java
@@ -41,7 +41,6 @@ public class Vorgang {
      * Art des Vortgangs.
      * Default ist ELEKTRONISCH
      */
-    @Builder.Default
     private VorgangArt art = VorgangArt.ELEKTRONISCH;
 
     public Vorgang(final NeuerVorgang neuerVorgang, final String coo) {

--- a/digiwf-libs/digiwf-email/digiwf-email-api/src/main/java/de/muenchen/oss/digiwf/email/model/Mail.java
+++ b/digiwf-libs/digiwf-email/digiwf-email-api/src/main/java/de/muenchen/oss/digiwf/email/model/Mail.java
@@ -21,7 +21,6 @@ public class Mail {
         private String subject;
         @NotBlank
         private String body;
-        @Builder.Default
         private boolean htmlBody = false;
         private String replyTo;
         private String receiversCc;


### PR DESCRIPTION
### Description

Fix initialized fields empty with `@Builder.Default`

### Reference

Issues: #1223

### Check-List

- [ ] All Acceptance criteria of user story are met
- [ ] JUnit tests are written (60% CodeCov)
- [ ] [Internal Review]([https://github.com/it-at-m/digiwf-core/blob/dev/CHANGELOG.md](https://confluence.muenchen.de/display/MPdZ/Review+-+DigiWF)) is maintained
- [ ] Documentations [external](https://github.com/it-at-m/digiwf-core/tree/dev/docs) and [internal](https://wiki.muenchen.de/betriebshandbuch/index.php?title=DigiWF&sfr=betriebshandbuch) are completed
- [ ] Smoketest successful (Manual E2E-Test depending on Change) 
- [ ] No Branch waste left
- [ ] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
- [ ] Openshift environments are prepared (Secrets, etc.) and release-issue is maintained
