### PR TITLE
Publicly serving of static files in API-Gateway

### DIFF
--- a/digiwf-gateway/src/main/java/de/muenchen/oss/digiwf/gateway/configuration/SecurityConfiguration.java
+++ b/digiwf-gateway/src/main/java/de/muenchen/oss/digiwf/gateway/configuration/SecurityConfiguration.java
@@ -70,6 +70,8 @@ public class SecurityConfiguration {
                   "/actuator/health",
                   "/actuator/info",
                   "/actuator/metrics").permitAll()
+              .pathMatchers(HttpMethod.OPTIONS, "/public/**").permitAll()
+              .pathMatchers(HttpMethod.GET, "/public/**").permitAll()
               // only authenticated
               .anyExchange().authenticated();
         })


### PR DESCRIPTION
### Description

Added pathmatcher for OPTIONS  and GET requests for serving publicly available files (like the planned webcomponents)

### Reference

Issues: closes #1317 

### Check-List

- [x] All Acceptance criteria of user story are met
- [ ] JUnit tests are written (60% CodeCov)
- [ ] [Internal Review]([https://github.com/it-at-m/digiwf-core/blob/dev/CHANGELOG.md](https://confluence.muenchen.de/display/MPdZ/Review+-+DigiWF)) is maintained
- [ ] Documentations [external](https://github.com/it-at-m/digiwf-core/tree/dev/docs) and [internal](https://wiki.muenchen.de/betriebshandbuch/index.php?title=DigiWF&sfr=betriebshandbuch) are completed
- [ ] Smoketest successful (Manual E2E-Test depending on Change) 
- [ ] No Branch waste left
- [ ] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
- [ ] Openshift environments are prepared (Secrets, etc.) and release-issue is maintained
