### PR TITLE
1310 add oracle driver to engine-rest-service

### DIFF
--- a/digiwf-engine/digiwf-engine-rest-service/pom.xml
+++ b/digiwf-engine/digiwf-engine-rest-service/pom.xml
@@ -81,6 +81,11 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc10</artifactId>
+            <version>${ojdbc10.version}</version>
+        </dependency>
 
         <!-- Validation -->
         <dependency>

--- a/digiwf-engine/digiwf-engine-service/pom.xml
+++ b/digiwf-engine/digiwf-engine-service/pom.xml
@@ -18,8 +18,6 @@
         <apache.commons.lang3>3.12.0</apache.commons.lang3>
         <apache.commons.text>1.11.0</apache.commons.text>
         <apache.commons.validator>1.8.0</apache.commons.validator>
-
-        <ojdbc10.version>19.22.0.0</ojdbc10.version>
         <javafaker.version>1.0.2</javafaker.version>
         <maven.deploy.skip>true</maven.deploy.skip>
         <cxf.version>3.6.2</cxf.version>

--- a/digiwf-engine/pom.xml
+++ b/digiwf-engine/pom.xml
@@ -19,6 +19,7 @@
         <camunda.version.ce>7.20.0</camunda.version.ce>
         <camunda.version>${camunda.version.ce}</camunda.version>
         <camunda.version.ee>7.20.0-ee</camunda.version.ee>
+        <ojdbc10.version>19.22.0.0</ojdbc10.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
### Description

add oracle driver to engine-rest-service

### Reference

Issues: closes #1310

### Check-List

- [ ] All Acceptance criteria of user story are met
- [ ] JUnit tests are written (60% CodeCov)
- [ ] [Internal Review]([https://github.com/it-at-m/digiwf-core/blob/dev/CHANGELOG.md](https://confluence.muenchen.de/display/MPdZ/Review+-+DigiWF)) is maintained
- [ ] Documentations [external](https://github.com/it-at-m/digiwf-core/tree/dev/docs) and [internal](https://wiki.muenchen.de/betriebshandbuch/index.php?title=DigiWF&sfr=betriebshandbuch) are completed
- [ ] Smoketest successful (Manual E2E-Test depending on Change) 
- [ ] No Branch waste left
- [ ] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
- [ ] Openshift environments are prepared (Secrets, etc.) and release-issue is maintained
