### PR TITLE
Default Reply-Mail-Address

### DIFF
--- a/digiwf-libs/digiwf-email/digiwf-email-api/src/main/java/de/muenchen/oss/digiwf/email/impl/DigiwfEmailApiImpl.java
+++ b/digiwf-libs/digiwf-email/digiwf-email-api/src/main/java/de/muenchen/oss/digiwf/email/impl/DigiwfEmailApiImpl.java
@@ -28,6 +28,7 @@ public class DigiwfEmailApiImpl implements DigiwfEmailApi {
     private final JavaMailSender mailSender;
     private final ResourceLoader resourceLoader;
     private final String fromAddress;
+    private final String defaultReplyToAddress;
     // use a prepackaged sanitizer to prevent XSS
     private final PolicyFactory policy = Sanitizers.BLOCKS
             .and(Sanitizers.FORMATTING)
@@ -59,6 +60,8 @@ public class DigiwfEmailApiImpl implements DigiwfEmailApi {
 
         if (mail.hasReplyTo()) {
             mimeMessage.setReplyTo(InternetAddress.parse(mail.getReplyTo()));
+        } else if (defaultReplyToAddress != null) {
+            mimeMessage.setReplyTo(InternetAddress.parse(defaultReplyToAddress));
         }
 
         final var helper = new MimeMessageHelper(mimeMessage, true, StandardCharsets.UTF_8.name());

--- a/digiwf-libs/digiwf-email/digiwf-email-api/src/test/java/de/muenchen/oss/digiwf/email/DigiwfEmailApiImplTest.java
+++ b/digiwf-libs/digiwf-email/digiwf-email-api/src/test/java/de/muenchen/oss/digiwf/email/DigiwfEmailApiImplTest.java
@@ -47,7 +47,7 @@ class DigiwfEmailApiImplTest {
     private final String subject = "Test Mail";
     private final String body = "This is a test mail";
     private final String replyTo = "digiwf@muenchen.de";
-    private final String defaultReplyTo = "no-reply@muenchen.de";
+    private final String defaultReplyTo = "noreply@muenchen.de";
     private final String sender = "some-custom-sender@muenchen.de";
 
 

--- a/digiwf-libs/digiwf-email/digiwf-email-api/src/test/java/de/muenchen/oss/digiwf/email/DigiwfEmailApiImplTest.java
+++ b/digiwf-libs/digiwf-email/digiwf-email-api/src/test/java/de/muenchen/oss/digiwf/email/DigiwfEmailApiImplTest.java
@@ -28,7 +28,10 @@ import java.util.Map;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class DigiwfEmailApiImplTest {
 
@@ -44,13 +47,14 @@ class DigiwfEmailApiImplTest {
     private final String subject = "Test Mail";
     private final String body = "This is a test mail";
     private final String replyTo = "digiwf@muenchen.de";
+    private final String defaultReplyTo = "no-reply@muenchen.de";
     private final String sender = "some-custom-sender@muenchen.de";
 
 
     @BeforeEach
     void setUp() {
         when(this.javaMailSender.createMimeMessage()).thenReturn(new MimeMessage((Session) null));
-        this.digiwfEmailApi = new DigiwfEmailApiImpl(this.javaMailSender, this.resourceLoader, "digiwf@muenchen.de");
+        this.digiwfEmailApi = new DigiwfEmailApiImpl(this.javaMailSender, this.resourceLoader, "digiwf@muenchen.de", defaultReplyTo);
     }
 
     @Test
@@ -67,6 +71,30 @@ class DigiwfEmailApiImplTest {
 
         assertThat(messageArgumentCaptor.getValue().getAllRecipients()).hasSize(2);
         assertThat(messageArgumentCaptor.getValue().getSubject()).isEqualTo(this.subject);
+        assertThat(messageArgumentCaptor.getValue().getReplyTo()).hasSize(1);
+        assertThat(messageArgumentCaptor.getValue().getReplyTo()).contains(new InternetAddress(this.defaultReplyTo));
+        final MimeMultipart content = (MimeMultipart) messageArgumentCaptor.getValue().getContent();
+        assertThat(content.getContentType()).contains("multipart/mixed");
+    }
+
+    @Test
+    void testSendMailNoDefaultReplyTo() throws MessagingException, IOException {
+        var customAddress = new InternetAddress("custom.digiwf@muenchen.de");
+
+        final Mail mail = Mail.builder()
+                .receivers(this.receiver)
+                .subject(this.subject)
+                .body(this.body)
+                .build();
+        new DigiwfEmailApiImpl(this.javaMailSender, this.resourceLoader, customAddress.getAddress(), null).sendMail(mail);
+
+        final ArgumentCaptor<MimeMessage> messageArgumentCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(this.javaMailSender).send(messageArgumentCaptor.capture());
+
+        assertThat(messageArgumentCaptor.getValue().getAllRecipients()).hasSize(2);
+        assertThat(messageArgumentCaptor.getValue().getSubject()).isEqualTo(this.subject);
+        assertThat(messageArgumentCaptor.getValue().getReplyTo()).hasSize(1);
+        assertThat(messageArgumentCaptor.getValue().getReplyTo()).contains(new InternetAddress(customAddress.getAddress()));
         final MimeMultipart content = (MimeMultipart) messageArgumentCaptor.getValue().getContent();
         assertThat(content.getContentType()).contains("multipart/mixed");
     }
@@ -93,6 +121,7 @@ class DigiwfEmailApiImplTest {
         );
         assertThat(messageArgumentCaptor.getValue().getSubject()).isEqualTo(this.subject);
         assertThat(messageArgumentCaptor.getValue().getReplyTo()).hasSize(1);
+        assertThat(messageArgumentCaptor.getValue().getReplyTo()).contains(new InternetAddress(this.replyTo));
         assertThat(messageArgumentCaptor.getValue().getFrom()).contains(new InternetAddress(this.sender));
         final MimeMultipart content = (MimeMultipart) messageArgumentCaptor.getValue().getContent();
         assertThat(content.getContentType()).contains("multipart/mixed");
@@ -121,11 +150,14 @@ class DigiwfEmailApiImplTest {
 
     @Test
     void sendMailWithMultipleReplyToAddresses() throws MessagingException, IOException {
+        var reply1 = new InternetAddress("address1@muenchen.de");
+        var reply2 = new InternetAddress("address2@muenchen.de");
+
         final Mail mail = Mail.builder()
                 .receivers(this.receiver)
                 .subject(this.subject)
                 .body(this.body)
-                .replyTo("address1@muenchen.de, address2@muenchen.de")
+                .replyTo(reply1.getAddress() + "," + reply2.getAddress())
                 .build();
         this.digiwfEmailApi.sendMail(mail);
 
@@ -135,6 +167,7 @@ class DigiwfEmailApiImplTest {
         assertThat(messageArgumentCaptor.getValue().getAllRecipients()).hasSize(2);
         assertThat(messageArgumentCaptor.getValue().getSubject()).isEqualTo(this.subject);
         assertThat(messageArgumentCaptor.getValue().getReplyTo()).hasSize(2);
+        assertThat(messageArgumentCaptor.getValue().getReplyTo()).containsAll(List.of(reply1, reply2));
         final MimeMultipart content = (MimeMultipart) messageArgumentCaptor.getValue().getContent();
         assertThat(content.getContentType()).contains("multipart/mixed");
     }

--- a/digiwf-libs/digiwf-email/digiwf-email-starter/src/main/java/de/muenchen/oss/digiwf/email/configuration/DigiwfEmailAutoConfiguration.java
+++ b/digiwf-libs/digiwf-email/digiwf-email-starter/src/main/java/de/muenchen/oss/digiwf/email/configuration/DigiwfEmailAutoConfiguration.java
@@ -47,7 +47,7 @@ public class DigiwfEmailAutoConfiguration {
     @ConditionalOnMissingBean
     @Bean
     public DigiwfEmailApi digiwfEmailApi(final ResourceLoader resourceLoader, final JavaMailSender javaMailSender) {
-        return new DigiwfEmailApiImpl(javaMailSender, resourceLoader, this.customMailProperties.getFromAddress());
+        return new DigiwfEmailApiImpl(javaMailSender, resourceLoader, this.customMailProperties.getFromAddress(), this.customMailProperties.getDefaultReplyToAddress());
     }
 
 }

--- a/digiwf-libs/digiwf-email/digiwf-email-starter/src/main/java/de/muenchen/oss/digiwf/email/properties/CustomMailProperties.java
+++ b/digiwf-libs/digiwf-email/digiwf-email-starter/src/main/java/de/muenchen/oss/digiwf/email/properties/CustomMailProperties.java
@@ -12,4 +12,9 @@ public class CustomMailProperties {
      */
     private String fromAddress;
 
+    /**
+     * Default Reply-to mail address, e.g. no-reply@domain
+     */
+    private String defaultReplyToAddress;
+
 }

--- a/docs/src/documentation/libs/digiwf-email/README.md
+++ b/docs/src/documentation/libs/digiwf-email/README.md
@@ -30,6 +30,7 @@ Diese bestehen aus einem Dateinamen und einem `ByteArrayDataSource`, der den Inh
 ## Konfiguration
 
 Die E-Mail Konfiguration erlaubt es einen default Wert für den Absender der E-Mails zu setzen mit der Property `io.muenchendigital.digiwf.mail.fromAddress`.
+Zusätzlich kann eine Standard-Reply-To Adresse gesetzt werden für technische Mails ohne Rückkanal mit der Property `io.muenchendigital.digiwf.mail.defaultReplyToAddress`.
 Alle weiteren Konfiguration werden direkt über die Spring Mail Konfiguration vorgenommen.
 
 ```yaml

--- a/docs/src/integrations/digiwf-mail-integration.md
+++ b/docs/src/integrations/digiwf-mail-integration.md
@@ -146,7 +146,7 @@ io:
     digiwf:
       mail:
         fromAddress: ${MAIL_USERNAME:digiwf@muenchen.de}
-        defaultReplyToAddress: ${MAIL_NO-REPLY:no-reply@muenchen.de}
+        defaultReplyToAddress: ${MAIL_NO-REPLY:noreply@muenchen.de}
         metrics:
           totalMailCounterName: "digiwf.email.integration.send_mail.total"
           failureCounterName: "digiwf.email.integration.send_mail.failure"

--- a/docs/src/integrations/digiwf-mail-integration.md
+++ b/docs/src/integrations/digiwf-mail-integration.md
@@ -135,6 +135,7 @@ sind, können Sie die folgenden Konfigurationen für die DigiWF Mail Integration
 |                                                               |                                                                                                                |
 |---------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
 | `io.muenchendigital.digiwf.mail.fromAddress`                  | Die Absenderadresse, die für alle Emails verwendet wird, die über die DigiWF Mail Integration gesendet werden. |
+| `io.muenchendigital.digiwf.mail.defaultReplyToAddress`        | Eine Standard-Reply-To-Mailadresse für technische Mails, auf die nicht geantwortet werden soll.                |
 | `io.muenchendigital.digiwf.mail.metrics.totalMailCounterName` | Der Name des Micrometer Counters, der die Anzahl der gesendeten Emails zählt.                                  |
 | `io.muenchendigital.digiwf.mail.metrics.failureCounterName`   | Der Name des Micrometer Counters, der die Anzahl der fehlgeschlagenen Emails zählt.                            |
 
@@ -145,6 +146,7 @@ io:
     digiwf:
       mail:
         fromAddress: ${MAIL_USERNAME:digiwf@muenchen.de}
+        defaultReplyToAddress: ${MAIL_NO-REPLY:no-reply@muenchen.de}
         metrics:
           totalMailCounterName: "digiwf.email.integration.send_mail.total"
           failureCounterName: "digiwf.email.integration.send_mail.failure"


### PR DESCRIPTION
### Description

Add a default Reply-Address for No-Reply Mails

## Screenshots (If UI changed)

### Reference

no ref

### Check-List

- [x] All Acceptance criteria of user story are met
- [x] Accessibility was considered and tested (On UI Change)
- [x] JUnit tests are written (60% CodeCov)
- [ ] [Internal Review]([https://github.com/it-at-m/digiwf-core/blob/dev/CHANGELOG.md](https://confluence.muenchen.de/display/MPdZ/Review+-+DigiWF)) is maintained
- [x] Documentations [external](https://github.com/it-at-m/digiwf-core/tree/dev/docs) and [internal](https://wiki.muenchen.de/betriebshandbuch/index.php?title=DigiWF&sfr=betriebshandbuch) are completed
- [ ] Smoketest successful (Manual E2E-Test depending on Change) 
- [x] No waste on Branch left (e.g. `console.logs`)
- [x] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
- [ ] Openshift environments are prepared (Secrets, etc.) and release-issue is maintained
