### PR TITLE
Fix: DMS-Input returns COOs

### DIFF
--- a/digiwf-apps/packages/components/digiwf-dms-input/src/components/DwfDmsInput.vue
+++ b/digiwf-apps/packages/components/digiwf-dms-input/src/components/DwfDmsInput.vue
@@ -140,8 +140,8 @@ export default defineComponent({
 
     const getMetadataOfObjects = (objects: DmsObject[]) => {
       return objects
-        .map(doc => doc.metadata)
-        .filter(metadata => !!metadata);
+        .filter(doc => !!doc.metadata)
+        .map(doc => doc.coo);
     }
 
     const validate = (number: number) => {


### PR DESCRIPTION
### Description

DMS-Input Returns List of COOs instead of Metadata

## Screenshots (If UI changed)

### Reference

Issues: closes #881 

### Check-List

- [ ] All Acceptance criteria of user story are met
- [ ] Accessibility was considered and tested (On UI Change)
- [ ] JUnit tests are written (60% CodeCov)
- [ ] [Internal Review]([https://github.com/it-at-m/digiwf-core/blob/dev/CHANGELOG.md](https://confluence.muenchen.de/display/MPdZ/Review+-+DigiWF)) is maintained
- [ ] Documentations [external](https://github.com/it-at-m/digiwf-core/tree/dev/docs) and [internal](https://wiki.muenchen.de/betriebshandbuch/index.php?title=DigiWF&sfr=betriebshandbuch) are completed
- [ ] Smoketest successful (Manual E2E-Test depending on Change) 
- [ ] No waste on Branch left (e.g. `console.logs`)
- [ ] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
- [ ] Openshift environments are prepared (Secrets, etc.) and release-issue is maintained
