### PR TITLE
Filter ProcessDefinitions on Startable

### DIFF
--- a/digiwf-engine/digiwf-engine-service/src/main/java/de/muenchen/oss/digiwf/process/definition/domain/service/ServiceDefinitionService.java
+++ b/digiwf-engine/digiwf-engine-service/src/main/java/de/muenchen/oss/digiwf/process/definition/domain/service/ServiceDefinitionService.java
@@ -21,6 +21,8 @@ import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.bpm.engine.variable.Variables;
 import org.springframework.stereotype.Service;
 
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 
@@ -56,6 +58,7 @@ public class ServiceDefinitionService {
 
         //add other serializer
         variables.put(ProcessConstants.PROCESS_STARTER_OF_INSTANCE, userId);
+        variables.put(ProcessConstants.PROCESS_START_DATE, ZonedDateTime.now().format( DateTimeFormatter.ISO_INSTANT ));
         variables.put(ProcessConstants.PROCESS_STATUS, "Gestartet");
         variables.put(ProcessConstants.PROCESS_FILE_CONTEXT, startContext.getFileContext());
         variables.put(ProcessConstants.PROCESS_INFO_ID, Variables.stringValue(serviceInstance.getId(), true));
@@ -103,6 +106,8 @@ public class ServiceDefinitionService {
      */
     public List<ServiceDefinition> getServiceDefinitions() {
         final List<ProcessDefinition> serviceDefinitions = this.repositoryService.createProcessDefinitionQuery()
+                .startableInTasklist()
+                .active()
                 .latestVersion()
                 .list();
         return this.serviceDefinitionMapper.map(serviceDefinitions);

--- a/digiwf-engine/digiwf-engine-service/src/main/java/de/muenchen/oss/digiwf/process/instance/process/ProcessConstants.java
+++ b/digiwf-engine/digiwf-engine-service/src/main/java/de/muenchen/oss/digiwf/process/instance/process/ProcessConstants.java
@@ -13,6 +13,8 @@ public class ProcessConstants {
 
     public static final String PROCESS_STATUS = "app_process_status";
 
+    public static final String PROCESS_START_DATE = "app_process_start_date";
+
     public static final String PROCESS_INFO_ID = "app_process_info_id";
 
     public static final String PROCESS_FILE_CONTEXT = "app_file_context";

--- a/digiwf-engine/digiwf-engine-service/src/main/resources/bausteine/basis/duplikatepruefen/DuplikatePruefenV01.bpmn
+++ b/digiwf-engine/digiwf-engine-service/src/main/resources/bausteine/basis/duplikatepruefen/DuplikatePruefenV01.bpmn
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1foapfc" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.4.0">
-  <bpmn:process id="DuplikatePruefenV01" name="Duplikate prüfen" isExecutable="true" camunda:candidateStarterGroups="nobody">
+  <bpmn:process id="DuplikatePruefenV01" name="Duplikate prüfen" isExecutable="true" camunda:candidateStarterGroups="nobody" camunda:isStartableInTasklist="false">
     <bpmn:startEvent id="StartEvent_PruefungGestartet" name="Prüfung gestartet" camunda:asyncBefore="true">
       <bpmn:outgoing>Flow_0qfo2xm</bpmn:outgoing>
     </bpmn:startEvent>

--- a/digiwf-engine/digiwf-engine-service/src/main/resources/bausteine/basis/duplikatepruefen/DuplikatePruefenV02.bpmn
+++ b/digiwf-engine/digiwf-engine-service/src/main/resources/bausteine/basis/duplikatepruefen/DuplikatePruefenV02.bpmn
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1foapfc" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.6.0">
-  <bpmn:process id="DuplikatePruefenV02" name="Duplikate prüfen" isExecutable="true" camunda:candidateStarterGroups="nobody">
+  <bpmn:process id="DuplikatePruefenV02" name="Duplikate prüfen" isExecutable="true" camunda:candidateStarterGroups="nobody" camunda:isStartableInTasklist="false">
     <bpmn:startEvent id="StartEvent_PruefungGestartet" name="Prüfung gestartet" camunda:asyncBefore="true">
       <bpmn:outgoing>Flow_0qfo2xm</bpmn:outgoing>
     </bpmn:startEvent>

--- a/digiwf-engine/digiwf-engine-service/src/main/resources/bausteine/streaming/StreamingTemplateIntegrationV01.bpmn
+++ b/digiwf-engine/digiwf-engine-service/src/main/resources/bausteine/streaming/StreamingTemplateIntegrationV01.bpmn
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0f11k6m" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
-  <bpmn:process id="StreamingTemplateV01" name="StreamingTemplateV01" isExecutable="true">
+  <bpmn:process id="StreamingTemplateV01" name="StreamingTemplateV01" isExecutable="true" camunda:isStartableInTasklist="false">
     <bpmn:startEvent id="StartEvent_1" name="Start Streaming">
       <bpmn:outgoing>Flow_0riqkf6</bpmn:outgoing>
     </bpmn:startEvent>

--- a/digiwf-engine/digiwf-engine-service/src/main/resources/bausteine/streaming/StreamingTemplateV02.bpmn
+++ b/digiwf-engine/digiwf-engine-service/src/main/resources/bausteine/streaming/StreamingTemplateV02.bpmn
@@ -6,7 +6,7 @@
                   xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0f11k6m"
                   targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.6.0"
                   modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
-  <bpmn:process id="StreamingTemplateV02" name="StreamingTemplateV02" isExecutable="true">
+  <bpmn:process id="StreamingTemplateV02" name="StreamingTemplateV02" isExecutable="true" camunda:isStartableInTasklist="false">
     <bpmn:startEvent id="StartEvent_1" name="Start Streaming">
       <bpmn:outgoing>Flow_0riqkf6</bpmn:outgoing>
     </bpmn:startEvent>

--- a/digiwf-engine/digiwf-engine-service/src/test/java/de/muenchen/oss/digiwf/process/definition/domain/service/ServiceDefinitionServiceTest.java
+++ b/digiwf-engine/digiwf-engine-service/src/test/java/de/muenchen/oss/digiwf/process/definition/domain/service/ServiceDefinitionServiceTest.java
@@ -1,0 +1,58 @@
+package de.muenchen.oss.digiwf.process.definition.domain.service;
+
+import de.muenchen.oss.digiwf.process.definition.domain.mapper.ServiceDefinitionMapper;
+import de.muenchen.oss.digiwf.process.definition.domain.model.ServiceDefinition;
+import de.muenchen.oss.digiwf.process.instance.domain.service.ServiceInstanceService;
+import org.camunda.bpm.engine.RepositoryService;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.repository.ProcessDefinition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import org.mockito.Answers;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+public class ServiceDefinitionServiceTest {
+
+    private final RepositoryService repositoryService = mock(RepositoryService.class, withSettings().defaultAnswer(Answers.RETURNS_DEEP_STUBS));
+    private final RuntimeService runtimeService = mock(RuntimeService.class);
+    private final ServiceInstanceService serviceInstanceService = mock(ServiceInstanceService.class);
+    private final ServiceDefinitionMapper serviceDefinitionMapper = Mappers.getMapper(ServiceDefinitionMapper.class);
+
+    private ServiceDefinitionService unitToTest;
+
+    @BeforeEach
+    void setup() {
+        unitToTest = new ServiceDefinitionService(repositoryService, runtimeService, serviceDefinitionMapper, serviceInstanceService);
+    }
+
+    @Test
+    void test_getServiceDefinitions() {
+
+        ProcessDefinition pd1 = mock(ProcessDefinition.class);
+        when(pd1.getKey()).thenReturn("service1");
+        ProcessDefinition pd2 = mock(ProcessDefinition.class);
+        when(pd2.getKey()).thenReturn("service2");
+        List<ProcessDefinition> pdList = Arrays.asList(pd1, pd2);
+
+        when(repositoryService.createProcessDefinitionQuery()
+                .startableInTasklist()
+                .active()
+                .latestVersion()
+                .list()
+        ).thenReturn(pdList);
+
+        List<ServiceDefinition> result = unitToTest.getServiceDefinitions();
+        assertThat(result)
+                .hasSize(2)
+                .extracting(ServiceDefinition::getKey)
+                .containsAnyOf("service1", "service2");
+    }
+}

--- a/docs/src/modeling/processes/modeling/README.md
+++ b/docs/src/modeling/processes/modeling/README.md
@@ -16,6 +16,9 @@ Für die Plattform und Camunda als verwendete Engine sind die folgenden Eigensch
   DigiWF sieht deshalb eine standardmäßig eingestellte Löschfrist von 185 Tagen (ca. 6 Monate) vor. Nach dieser Zeit
   werden die historischen Prozessdaten aus der Datenbank gelöscht. Sollten Sie für Ihren Prozess eine andere Anforderung
   für die Löschzeit haben, können Sie das in dem Properties-Panel des Modelers konfigurieren.
+- **Tasklist Configuration: Startable:** Mit diesem Flag kann gesteuert werden, ob der Prozess unter "Vorgang starten" in 
+  der DigiWF-Taskliste angezeigt wird. Für Prozessbausteine sollte dieses deaktiviert werden.
+  
 
 ![Example Process](~@source/modeling/processes/modeling/example_process.png)
 
@@ -26,12 +29,13 @@ DigiWF speichert in der Prozessinstanz verschiedene Variablen, die für die Mode
 - **starterOfInstance:** Der Benutzer, der die Prozessinstanz über die DigiWF Taskliste gestartet hat.
 - **app_file_context:** Der Kontext, in dem die Datei hochgeladen werden.
 - **app_task_tag:** Der Tag, der für die Aufgabe (Usertask) gesetzt wurde und nach dem gefiltert werden kann. Die Variable ist standardmäßig leer und muss in der Modellierung bei Bedarf gesetzt werden.
+- **app_process_status:** Bezeichnung des aktuellen Status, in der sich die Prozessinstanz befindet
+- **app_process_start_date:** Startzeitpunkt der Prozessinstanz (Nicht zu verwechseln mit Antragseingang)
 
 ::: warning
 Die folgenden Variablen stehen ebenfalls zur Verfügung, sollten aber nicht verwendet werden, da sie bald abgeschafft
 werden.
 :::
 
-- **app_process_status:** Bezeichung des aktuellen Status, in der sich die Prozessinstanz befindet
-- **app_process_status_key:** Key des aktuellen Status, in der sich die Prozessinstanz befindet
+- **app_process_info_id:** Id der aktuellen Prozessinstanz
 - **app_process_description:** Beschreibung der Prozessinstanz die über diese Funktion gesetzt werden kann


### PR DESCRIPTION
### Description

Filtert die ProzessDefinitions auf das Startable in Tasklist und Active Flag, damit die "Starte Vorgang" Liste in der UI nicht überflutet wird mit Prozessbausteinen oder alten Prozessen

Setzt zudem eine neue Prozessvariable mit dem Start-Datum der Prozess-Instanz

## Screenshots (If UI changed)
no UI Change

### Reference

no Ref

### Check-List

- [x] All Acceptance criteria of user story are met
- [x] Accessibility was considered and tested (On UI Change)
- [x] JUnit tests are written (60% CodeCov)
- [x] [Internal Review]([https://github.com/it-at-m/digiwf-core/blob/dev/CHANGELOG.md](https://confluence.muenchen.de/display/MPdZ/Review+-+DigiWF)) is maintained
- [x] Documentations [external](https://github.com/it-at-m/digiwf-core/tree/dev/docs) and [internal](https://wiki.muenchen.de/betriebshandbuch/index.php?title=DigiWF&sfr=betriebshandbuch) are completed
- [x] Smoketest successful (Manual E2E-Test depending on Change) 
- [x] No waste on Branch left (e.g. `console.logs`)
- [x] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
- [x] Openshift environments are prepared (Secrets, etc.) and release-issue is maintained
