### PR TITLE
1311 increase max size of db column key_ in table jsonschema to 255

### DIFF
--- a/digiwf-engine/digiwf-engine-service/src/main/resources/db/migration/oracle/V25_increase_possible_key_size_JsonSchema.sql
+++ b/digiwf-engine/digiwf-engine-service/src/main/resources/db/migration/oracle/V25_increase_possible_key_size_JsonSchema.sql
@@ -1,0 +1,1 @@
+alter table DWF_JSON_SCHEMA modify key_ varchar2(255 char);


### PR DESCRIPTION
### Description

increase max size of db column key_ in table jsonschema to 255

### Reference

Issues: closes #1311


### Check-List

- [ ] All Acceptance criteria of user story are met
- [ ] [Internal Review]([https://github.com/it-at-m/digiwf-core/blob/dev/CHANGELOG.md](https://confluence.muenchen.de/display/MPdZ/Review+-+DigiWF)) is maintained
- [ ] Smoketest successful (Manual E2E-Test depending on Change) 
- [ ] No waste on Branch left (e.g. `console.logs`)
- [ ] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
