### PR TITLE
docs fix modeling element-template migration for auto topics

### DIFF
--- a/docs/src/.vuepress/config.js
+++ b/docs/src/.vuepress/config.js
@@ -205,6 +205,7 @@ module.exports = {
                             children: [
                                 'guides/modeling-first-process/',
                                 'guides/form-v1-auf-v2/',
+                                'guides/element-template-migration/',
                             ]
                         },
                         {

--- a/docs/src/modeling/guides/element-template-migration/README.md
+++ b/docs/src/modeling/guides/element-template-migration/README.md
@@ -25,4 +25,4 @@ angezeigten Element-Template, der nachfolgenden Liste oder von den [Integrations
 - s3Integration
 - dmsIntegration
 
-![Element-Template-Migration Beispiel](migrate_et_topics_example.png)
+![Element-Template-Migration Beispiel](~@source/modeling/guides/element-template-migration/migrate_et_topics_example.png)


### PR DESCRIPTION
### Description

Fix new docs for migrating element templates to new topic settings.

### Reference

#1346

### Check-List

- [x] No waste on Branch left (e.g. `console.logs`)
- [x] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
