### PR TITLE
pom update maven filtering vars

### DIFF
--- a/digiwf-engine/digiwf-engine-rest-service/src/main/resources/application.yml
+++ b/digiwf-engine/digiwf-engine-rest-service/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 info:
   application:
-    name: @project.artifactId@
-    version: 0.1.0
+    name: '@project.artifactId@'
+    version: '@project.version@'
 
 camunda:
   bpm:
@@ -38,7 +38,7 @@ server:
     whitelabel:
       enabled: false
   shutdown: graceful
-      
+
 spring:
   application:
     name: ${info.application.name}

--- a/digiwf-engine/digiwf-engine-service/src/main/resources/application.yml
+++ b/digiwf-engine/digiwf-engine-service/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 info:
   application:
-    name: @project.artifactId@
-    version: 0.1.0
+    name: '@project.artifactId@'
+    version: '@project.version@'
 camunda:
   bpm:
     authorization:

--- a/digiwf-gateway/src/main/resources/application.yml
+++ b/digiwf-gateway/src/main/resources/application.yml
@@ -1,12 +1,13 @@
 info:
   application:
-    name: ${spring.application.name}
+    name: '@project.artifactId@'
+    version: '@project.version@'
     stage:
       color: ${STAGE_COLOR:#FFCC00}
       displayName: ${STAGE_DISPLAY_NAME:${DIGIWF_ENV}}
 spring:
   application:
-    name: @project.artifactId@
+    name: ${info.application.name}
   main:
     web-application-type: reactive
   jackson:

--- a/digiwf-integrations/digiwf-address-integration/digiwf-address-integration-service/src/main/resources/application.yml
+++ b/digiwf-integrations/digiwf-address-integration/digiwf-address-integration-service/src/main/resources/application.yml
@@ -25,7 +25,7 @@ server:
   shutdown: graceful
 spring:
   application:
-    name: @project.artifactId@
+    name: '@project.artifactId@'
   lifecycle:
     timeout-per-shutdown-phase: 1m
   cloud:

--- a/digiwf-integrations/digiwf-alw-integration/digiwf-alw-integration-service/src/main/resources/application.yml
+++ b/digiwf-integrations/digiwf-alw-integration/digiwf-alw-integration-service/src/main/resources/application.yml
@@ -22,11 +22,11 @@ io:
 
 info:
   application:
-    name: @project.artifactId@
-    version: @project.version@
+    name: '@project.artifactId@'
+    version: '@project.version@'
 
 spring:
-  application.name: @project.artifactId@
+  application.name: ${info.application.name}
   banner.location: banner.txt
   cloud:
     stream:

--- a/digiwf-integrations/digiwf-cosys-integration/digiwf-cosys-integration-service/src/main/resources/application.yml
+++ b/digiwf-integrations/digiwf-cosys-integration/digiwf-cosys-integration-service/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   application:
-    name: @project.artifactId@
+    name: '@project.artifactId@'
 
 io:
   muenchendigital:

--- a/digiwf-integrations/digiwf-dms-integration/digiwf-dms-integration-service/src/main/resources/application.yml
+++ b/digiwf-integrations/digiwf-dms-integration/digiwf-dms-integration-service/src/main/resources/application.yml
@@ -3,7 +3,7 @@ server:
   shutdown: graceful
 spring:
   application:
-    name: @project.artifactId@
+    name: '@project.artifactId@'
   cloud:
     stream:
       bindings:

--- a/digiwf-integrations/digiwf-email-integration/digiwf-email-integration-service/src/main/resources/application.yml
+++ b/digiwf-integrations/digiwf-email-integration/digiwf-email-integration-service/src/main/resources/application.yml
@@ -3,7 +3,7 @@ server:
   shutdown: graceful
 spring:
   application:
-    name: @project.artifactId@
+    name: '@project.artifactId@'
   cloud:
     stream:
       bindings:

--- a/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-service/src/main/resources/application.yml
+++ b/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-service/src/main/resources/application.yml
@@ -1,11 +1,11 @@
 info:
   application:
-    name: @project.artifactId@
-    version: @project.version@
+    name: '@project.artifactId@'
+    version: '@project.version@'
 
 spring:
   application:
-    name: @project.artifactId@
+    name: ${info.application.name}
   # Spring JPA
   datasource:
     url: '${S3INTEGRATION_DATASOURCE_URL}'

--- a/digiwf-integrations/digiwf-ticket-integration/digiwf-ticket-integration-service/src/main/resources/application.yml
+++ b/digiwf-integrations/digiwf-ticket-integration/digiwf-ticket-integration-service/src/main/resources/application.yml
@@ -18,11 +18,11 @@ io:
 
 info:
   application:
-    name: @project.artifactId@
-    version: @project.version@
+    name: '@project.artifactId@'
+    version: '@project.version@'
 
 spring:
-  application.name: @project.artifactId@
+  application.name: ${info.application.name}
   banner.location: banner.txt
   cloud:
     stream:

--- a/digiwf-task/digiwf-tasklist-service/src/main/resources/application.yml
+++ b/digiwf-task/digiwf-tasklist-service/src/main/resources/application.yml
@@ -2,7 +2,7 @@ server:
   port: ${TASKSERVICE_SERVER_PORT}
   shutdown: graceful
 spring:
-  application.name: @project.artifactId@
+  application.name: '@project.artifactId@'
   profiles:
     active: no-ldap # this profile is activating mock group resolution and should be replaced by the LDAP-aware client on production
   datasource:


### PR DESCRIPTION
### Description

Fix failing local start with error yaml can't parse maven filtering.

If started directly by idea the placeholders aren't replaced anymore but at build everything should work as intended.
In the created target jar the playholders are replaced.

### Check-List
- [x] No waste on Branch left (e.g. `console.logs`)
- [x] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
