### PR TITLE
chore(deps): bump polyflow.version from 4.1.2 to 4.1.4 (#1409)

### DIFF
--- a/digiwf-task/pom.xml
+++ b/digiwf-task/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <kotlin.version>1.9.22</kotlin.version>
         <camunda.version>7.20.0</camunda.version>
-        <polyflow.version>4.1.2</polyflow.version>
+        <polyflow.version>4.1.4</polyflow.version>
         <camunda-bpm-data.version>1.5.0</camunda-bpm-data.version>
     </properties>
 


### PR DESCRIPTION
Bumps `polyflow.version` from 4.1.2 to 4.1.4.

Updates `io.holunda.polyflow:polyflow-taskpool-dependencies` from 4.1.2 to 4.1.4

Updates `io.holunda.polyflow:polyflow-datapool-dependencies` from 4.1.2 to 4.1.4

Updates `io.holunda.polyflow:polyflow-bus-jackson` from 4.1.2 to 4.1.4

---
updated-dependencies:
- dependency-name: io.holunda.polyflow:polyflow-taskpool-dependencies dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: io.holunda.polyflow:polyflow-datapool-dependencies dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: io.holunda.polyflow:polyflow-bus-jackson dependency-type: direct:production update-type: version-update:semver-patch ...

### Check-List

- [x] No waste on Branch left (e.g. `console.logs`)
- [x] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date