### PR TITLE
Fix Error on RootProcess of Message/Timer started Processes

### DIFF
--- a/digiwf-connector/digiwf-camunda-rest-connector-starter/src/main/java/de/muenchen/oss/digiwf/connector/adapter/camunda/rest/in/CamundaClient.java
+++ b/digiwf-connector/digiwf-camunda-rest-connector-starter/src/main/java/de/muenchen/oss/digiwf/connector/adapter/camunda/rest/in/CamundaClient.java
@@ -7,6 +7,7 @@ import de.muenchen.oss.digiwf.connector.core.domain.IntegrationNameConfigExcepti
 import de.muenchen.oss.digiwf.connector.core.domain.ProcessDefinitionLoadingException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.camunda.bpm.client.task.ExternalTask;
 import org.camunda.bpm.client.task.ExternalTaskHandler;
 import org.camunda.bpm.client.task.ExternalTaskService;
@@ -52,6 +53,8 @@ public class CamundaClient implements ExternalTaskHandler {
             externalTaskService.handleFailure(externalTask, e.getMessage(), e.getDetailedMessage(), 0, 0);
         } catch (final ProcessDefinitionLoadingException e) {
             externalTaskService.handleFailure(externalTask, e.getMessage(), e.getDetailedMessage(), 0, 0);
+        } catch (final Exception e) {
+            externalTaskService.handleFailure(externalTask, e.getMessage(), ExceptionUtils.getStackTrace(e),0, 0);
         }
     }
 

--- a/digiwf-engine/digiwf-engine-service/src/main/java/de/muenchen/oss/digiwf/process/instance/domain/service/ServiceInstanceService.java
+++ b/digiwf-engine/digiwf-engine-service/src/main/java/de/muenchen/oss/digiwf/process/instance/domain/service/ServiceInstanceService.java
@@ -127,13 +127,15 @@ public class ServiceInstanceService {
                     if (historicProcessInstance == null) {
                         throw new IllegalArgumentException("No process instance found for id: " + instanceId);
                     }
-                    return Optional.of(new ServiceInstance(null,
+                    return Optional.of(new ServiceInstance(
+                            null, // Camunda Only Process without DigiWF-Instance-Info
                             instance.getRootProcessInstanceId(),
                             historicProcessInstance.getProcessDefinitionName(),
                             historicProcessInstance.getProcessDefinitionKey(),
                             historicProcessInstance.getStartTime(),
                             historicProcessInstance.getEndTime(),
                             historicProcessInstance.getRemovalTime(),
+                            //No Status/Description on non DigiWF processes
                             null,
                             null,
                             null));

--- a/digiwf-engine/digiwf-engine-service/src/main/java/de/muenchen/oss/digiwf/process/instance/domain/service/ServiceInstanceService.java
+++ b/digiwf-engine/digiwf-engine-service/src/main/java/de/muenchen/oss/digiwf/process/instance/domain/service/ServiceInstanceService.java
@@ -20,6 +20,7 @@ import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.camunda.bpm.engine.HistoryService;
 import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.history.HistoricProcessInstance;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -117,7 +118,27 @@ public class ServiceInstanceService {
 
         return this.processInstanceInfoRepository.findByInstanceId(instance.getRootProcessInstanceId())
                 .map(this.serviceInstanceMapper::map2Model)
-                .orElseThrow();
+                .or(() -> {
+                    //TODO Remove after #545 is fixed
+                    final HistoricProcessInstance historicProcessInstance = this.historyService.createHistoricProcessInstanceQuery()
+                            .processInstanceId(instanceId)
+                            .singleResult();
+
+                    if (historicProcessInstance == null) {
+                        throw new IllegalArgumentException("No process instance found for id: " + instanceId);
+                    }
+                    return Optional.of(new ServiceInstance(null,
+                            instance.getRootProcessInstanceId(),
+                            historicProcessInstance.getProcessDefinitionName(),
+                            historicProcessInstance.getProcessDefinitionKey(),
+                            historicProcessInstance.getStartTime(),
+                            historicProcessInstance.getEndTime(),
+                            historicProcessInstance.getRemovalTime(),
+                            null,
+                            null,
+                            null));
+                }).orElseThrow();
+
     }
 
     /**


### PR DESCRIPTION
### Description

* Handle every Error on Connector 
* Get Definition-Key on RootProcess of Message/Timer started Processes

### Reference

Issues: [internal#447](https://git.muenchen.de/digitalisierung/digiwf-support/-/issues/447)

### Screenshots (If UI changed)

no-uichange

### Check-List

- [x] All Acceptance criteria of user story are met
- [ ] ~~Accessibility was considered and tested (On UI Change)~~
- [x] JUnit tests are written (60% CodeCov)
- [x] [Internal Review]([https://github.com/it-at-m/digiwf-core/blob/dev/CHANGELOG.md](https://confluence.muenchen.de/display/MPdZ/Review+-+DigiWF)) is maintained
- [ ] ~~Documentations [external](https://github.com/it-at-m/digiwf-core/tree/dev/docs) and [internal](https://wiki.muenchen.de/betriebshandbuch/index.php?title=DigiWF&sfr=betriebshandbuch) are completed~~
- [ ] ~~Smoketest successful (Manual E2E-Test depending on Change)~~ Wird mit Reporter-Prozess auf Demo getestet
- [x] No waste on Branch left (e.g. `console.logs`)
- [ ] ~~[Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date~~
- [ ] ~~Openshift environments are prepared (Secrets, etc.) and release-issue is maintained~~
