### PR TITLE
dockerfiles use ubi9, fix startup, rm default expose

### DIFF
--- a/digiwf-connector/digiwf-camunda-connector-service/Dockerfile
+++ b/digiwf-connector/digiwf-camunda-connector-service/Dockerfile
@@ -1,7 +1,3 @@
-FROM registry.access.redhat.com/ubi8/openjdk-17:latest
-
-EXPOSE 8080
+FROM registry.access.redhat.com/ubi9/openjdk-17:latest
 
 COPY target/*.jar /deployments/spring-boot-application.jar
-
-CMD "java" ${JAVA_OPTIONS} "-jar" "/deployments/spring-boot-application.jar"

--- a/digiwf-engine/digiwf-engine-rest-service/Dockerfile
+++ b/digiwf-engine/digiwf-engine-rest-service/Dockerfile
@@ -1,7 +1,3 @@
-FROM registry.access.redhat.com/ubi8/openjdk-17:latest
-
-EXPOSE 8080
+FROM registry.access.redhat.com/ubi9/openjdk-17:latest
 
 COPY target/*.jar /deployments/spring-boot-application.jar
-
-CMD "java" ${JAVA_OPTIONS} "-jar" "/deployments/spring-boot-application.jar"

--- a/digiwf-engine/digiwf-engine-service/Dockerfile
+++ b/digiwf-engine/digiwf-engine-service/Dockerfile
@@ -1,7 +1,3 @@
-FROM registry.access.redhat.com/ubi8/openjdk-17:latest
-
-EXPOSE 8080
+FROM registry.access.redhat.com/ubi9/openjdk-17:latest
 
 COPY target/*.jar /deployments/spring-boot-application.jar
-
-CMD "java" ${JAVA_OPTIONS} "-jar" "/deployments/spring-boot-application.jar"

--- a/digiwf-gateway/Dockerfile
+++ b/digiwf-gateway/Dockerfile
@@ -1,7 +1,3 @@
-FROM registry.access.redhat.com/ubi8/openjdk-17:latest
-
-EXPOSE 8080
+FROM registry.access.redhat.com/ubi9/openjdk-17:latest
 
 COPY target/*.jar /deployments/spring-boot-application.jar
-
-CMD "java" ${JAVA_OPTIONS} "-jar" "/deployments/spring-boot-application.jar"

--- a/digiwf-integrations/digiwf-address-integration/digiwf-address-integration-service/Dockerfile
+++ b/digiwf-integrations/digiwf-address-integration/digiwf-address-integration-service/Dockerfile
@@ -1,7 +1,3 @@
-FROM registry.access.redhat.com/ubi8/openjdk-17:latest
-
-EXPOSE 8080
+FROM registry.access.redhat.com/ubi9/openjdk-17:latest
 
 COPY target/*.jar /deployments/spring-boot-application.jar
-
-CMD "java" ${JAVA_OPTIONS} "-jar" "/deployments/spring-boot-application.jar"

--- a/digiwf-integrations/digiwf-alw-integration/digiwf-alw-integration-service/Dockerfile
+++ b/digiwf-integrations/digiwf-alw-integration/digiwf-alw-integration-service/Dockerfile
@@ -1,7 +1,3 @@
-FROM registry.access.redhat.com/ubi8/openjdk-17:latest
-
-EXPOSE 8080
+FROM registry.access.redhat.com/ubi9/openjdk-17:latest
 
 COPY target/*.jar /deployments/spring-boot-application.jar
-
-CMD "java" ${JAVA_OPTIONS} "-jar" "/deployments/spring-boot-application.jar"

--- a/digiwf-integrations/digiwf-cosys-integration/digiwf-cosys-integration-service/Dockerfile
+++ b/digiwf-integrations/digiwf-cosys-integration/digiwf-cosys-integration-service/Dockerfile
@@ -1,7 +1,3 @@
-FROM registry.access.redhat.com/ubi8/openjdk-17:latest
-
-EXPOSE 8080
+FROM registry.access.redhat.com/ubi9/openjdk-17:latest
 
 COPY target/*.jar /deployments/spring-boot-application.jar
-
-CMD "java" ${JAVA_OPTIONS} "-jar" "/deployments/spring-boot-application.jar"

--- a/digiwf-integrations/digiwf-dms-integration/digiwf-dms-integration-service/Dockerfile
+++ b/digiwf-integrations/digiwf-dms-integration/digiwf-dms-integration-service/Dockerfile
@@ -1,7 +1,3 @@
-FROM registry.access.redhat.com/ubi8/openjdk-17:latest
-
-EXPOSE 8080
+FROM registry.access.redhat.com/ubi9/openjdk-17:latest
 
 COPY target/*.jar /deployments/spring-boot-application.jar
-
-CMD "java" ${JAVA_OPTIONS} "-jar" "/deployments/spring-boot-application.jar"

--- a/digiwf-integrations/digiwf-email-integration/digiwf-email-integration-service/Dockerfile
+++ b/digiwf-integrations/digiwf-email-integration/digiwf-email-integration-service/Dockerfile
@@ -1,7 +1,3 @@
-FROM registry.access.redhat.com/ubi8/openjdk-17:latest
-
-EXPOSE 8080
+FROM registry.access.redhat.com/ubi9/openjdk-17:latest
 
 COPY target/*.jar /deployments/spring-boot-application.jar
-
-CMD "java" ${JAVA_OPTIONS} "-jar" "/deployments/spring-boot-application.jar"

--- a/digiwf-integrations/digiwf-okewo-integration/digiwf-okewo-integration-service/Dockerfile
+++ b/digiwf-integrations/digiwf-okewo-integration/digiwf-okewo-integration-service/Dockerfile
@@ -1,7 +1,3 @@
-FROM registry.access.redhat.com/ubi8/openjdk-17:latest
-
-EXPOSE 8080
+FROM registry.access.redhat.com/ubi9/openjdk-17:latest
 
 COPY target/*.jar /deployments/spring-boot-application.jar
-
-CMD "java" ${JAVA_OPTIONS} "-jar" "/deployments/spring-boot-application.jar"

--- a/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-service/Dockerfile
+++ b/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-service/Dockerfile
@@ -1,7 +1,3 @@
-FROM registry.access.redhat.com/ubi8/openjdk-17:latest
-
-EXPOSE 8080
+FROM registry.access.redhat.com/ubi9/openjdk-17:latest
 
 COPY target/*.jar /deployments/spring-boot-application.jar
-
-CMD "java" ${JAVA_OPTIONS} "-jar" "/deployments/spring-boot-application.jar"

--- a/digiwf-integrations/digiwf-ticket-integration/digiwf-ticket-integration-service/Dockerfile
+++ b/digiwf-integrations/digiwf-ticket-integration/digiwf-ticket-integration-service/Dockerfile
@@ -1,7 +1,3 @@
-FROM registry.access.redhat.com/ubi8/openjdk-17:latest
-
-EXPOSE 8080
+FROM registry.access.redhat.com/ubi9/openjdk-17:latest
 
 COPY target/*.jar /deployments/spring-boot-application.jar
-
-CMD "java" ${JAVA_OPTIONS} "-jar" "/deployments/spring-boot-application.jar"

--- a/digiwf-task/digiwf-tasklist-service/Dockerfile
+++ b/digiwf-task/digiwf-tasklist-service/Dockerfile
@@ -1,7 +1,3 @@
-FROM registry.access.redhat.com/ubi8/openjdk-17:latest
-
-EXPOSE 8080
+FROM registry.access.redhat.com/ubi9/openjdk-17:latest
 
 COPY target/*.jar /deployments/spring-boot-application.jar
-
-CMD "java" ${JAVA_OPTIONS} "-jar" "/deployments/spring-boot-application.jar"


### PR DESCRIPTION
### Description

- use ubi9 image
- rm expose which is by default 8080 and 8443
- rm custom cmd which breaks default startup

https://catalog.redhat.com/software/containers/ubi9/openjdk-17/61ee7c26ed74b2ffb22b07f6?architecture=amd64&image=65d3943bc148152c16e7169d&container-tabs=dockerfile

### Check-List

- [x] No waste on Branch left (e.g. `console.logs`)
- [x] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
