### PR TITLE
message-lib fix incident creation wrong headers

### DIFF
--- a/digiwf-libs/digiwf-message/digiwf-message-core/src/main/java/de/muenchen/oss/digiwf/message/process/impl/ErrorApiImpl.java
+++ b/digiwf-libs/digiwf-message/digiwf-message-core/src/main/java/de/muenchen/oss/digiwf/message/process/impl/ErrorApiImpl.java
@@ -31,9 +31,9 @@ public class ErrorApiImpl implements ErrorApi {
      * @return
      */
     @Override
-    public boolean handleIncident(final Map<String, Object>  originMessageHeaders, final String errorMessage) {
+    public boolean handleIncident(final Map<String, Object> originMessageHeaders, final String errorMessage) {
         final Map<String, Object> headers = Map.of(
-                TYPE, this.incidentDestination,
+                TYPE, originMessageHeaders.get(TYPE),
                 DIGIWF_PROCESS_INSTANCE_ID, originMessageHeaders.get(DIGIWF_PROCESS_INSTANCE_ID),
                 DIGIWF_INTEGRATION_NAME, originMessageHeaders.get(DIGIWF_INTEGRATION_NAME)
         );

--- a/digiwf-libs/digiwf-message/digiwf-message-core/src/test/java/de/muenchen/oss/digiwf/message/process/impl/ErrorApiImplTest.java
+++ b/digiwf-libs/digiwf-message/digiwf-message-core/src/test/java/de/muenchen/oss/digiwf/message/process/impl/ErrorApiImplTest.java
@@ -34,8 +34,9 @@ class ErrorApiImplTest {
     private final String incidentDestination = "incidentMessageDestination";
     private final String bpmnErrorDestination = "bpmnErrorMessageDestination";
     private final String integrationName = "exampleIntegration";
+    private final String typeName = "exampleType";
     private final Map<String, Object> messageHeaders = Map.of(DIGIWF_PROCESS_INSTANCE_ID, this.processInstanceId,
-            DIGIWF_INTEGRATION_NAME, this.integrationName);
+            DIGIWF_INTEGRATION_NAME, this.integrationName, TYPE, this.typeName);
 
 
     @BeforeEach
@@ -47,7 +48,7 @@ class ErrorApiImplTest {
     void testHandleIncident() {
         final boolean success = this.errorApi.handleIncident(messageHeaders, "someErrorMessage");
         assertThat(success).isTrue();
-        this.verifyIncidentMessageApiCall("someErrorMessage", this.incidentDestination, this.integrationName, this.incidentDestination);
+        this.verifyIncidentMessageApiCall("someErrorMessage", this.typeName, this.integrationName, this.incidentDestination);
     }
 
     @Test
@@ -79,7 +80,7 @@ class ErrorApiImplTest {
         final IncidentError incidentError = new IncidentError("someErrorMessage");
         final boolean success = this.errorApi.handleIncident(this.messageHeaders, incidentError);
         assertThat(success).isTrue();
-        this.verifyIncidentMessageApiCall("someErrorMessage", this.incidentDestination, this.integrationName, this.incidentDestination);
+        this.verifyIncidentMessageApiCall("someErrorMessage", this.typeName, this.integrationName, this.incidentDestination);
     }
 
     @Test


### PR DESCRIPTION
### Description

Fix message lib incident creation using wrong type header.

### Reference

Issues: #xxx

### Check-List

- [x] [Internal Review]([https://github.com/it-at-m/digiwf-core/blob/dev/CHANGELOG.md](https://confluence.muenchen.de/display/MPdZ/Review+-+DigiWF)) is maintained
- [x] Smoketest successful (Manual E2E-Test depending on Change) 
- [x] No waste on Branch left (e.g. `console.logs`)
- [x] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
