### PR TITLE
Fix maven release runs into timeout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -301,6 +301,8 @@
                             <serverId>ossrh</serverId>
                             <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
                             <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                            <stagingProgressPauseDurationSeconds>15</stagingProgressPauseDurationSeconds>
+                            <stagingProgressTimeoutMinutes>30</stagingProgressTimeoutMinutes>
                         </configuration>
                     </plugin>
 


### PR DESCRIPTION
### Description
<!-- Brief explanation of the changes and their impact -->
Fix maven release runs into timeout.

### Reference

### Screenshots (If UI changed)


### Check-List

- [x] All Acceptance criteria of user story are met
- [x] Accessibility was considered and tested (On UI Change)
- [x] JUnit tests are written (60% CodeCov)
- [x] [Internal Review]([https://github.com/it-at-m/digiwf-core/blob/dev/CHANGELOG.md](https://confluence.muenchen.de/display/MPdZ/Review+-+DigiWF)) is maintained
- [x] Documentations [external](https://github.com/it-at-m/digiwf-core/tree/dev/docs) and [internal](https://wiki.muenchen.de/betriebshandbuch/index.php?title=DigiWF&sfr=betriebshandbuch) are completed
- [x] Smoketest successful (Manual E2E-Test depending on Change) 
- [x] No waste on Branch left (e.g. `console.logs`)
- [x] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
- [x] Openshift environments are prepared (Secrets, etc.) and release-issue is maintained
