### PR TITLE
Bugfix/1480 prüfung dateiexistenz per abfrage von ordnerinhalten funktioniert nicht zuverlässig

### DIFF
--- a/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-core/src/main/java/de/muenchen/oss/digiwf/s3/integration/adapter/out/s3/S3Repository.java
+++ b/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-core/src/main/java/de/muenchen/oss/digiwf/s3/integration/adapter/out/s3/S3Repository.java
@@ -20,150 +20,154 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 public class S3Repository {
 
-  private final String bucketName;
-  private final String s3Url;
-  private final Optional<String> s3ProxyUrl;
-  private final MinioClient client;
+    private final String bucketName;
+    private final String s3Url;
+    private final Optional<String> s3ProxyUrl;
+    private final MinioClient client;
 
-  /**
-   * Ctor.
-   *
-   * @param bucketName              to which this Repository should connect.
-   * @param client                  to communicate with the s3 storage.
-   * @param s3InitialConnectionTest to enable initial connection test to the s3 storage when true.
-   * @throws FileSystemAccessException if the initial connection test fails.
-   */
-  public S3Repository(
-      final String bucketName,
-      final String s3Url,
-      final MinioClient client,
-      final boolean s3InitialConnectionTest,
-      final Optional<String> s3ProxyUrl
-  ) throws FileSystemAccessException {
-    this.bucketName = bucketName;
-    this.s3ProxyUrl = s3ProxyUrl;
-    this.s3Url = s3Url;
-    this.client = client;
-    if (s3InitialConnectionTest) {
-      this.initialConnectionTest(bucketName, client);
+    /**
+     * Ctor.
+     *
+     * @param bucketName              to which this Repository should connect.
+     * @param client                  to communicate with the s3 storage.
+     * @param s3InitialConnectionTest to enable initial connection test to the s3 storage when true.
+     * @throws FileSystemAccessException if the initial connection test fails.
+     */
+    public S3Repository(
+            final String bucketName,
+            final String s3Url,
+            final MinioClient client,
+            final boolean s3InitialConnectionTest,
+            final Optional<String> s3ProxyUrl
+    ) throws FileSystemAccessException {
+        this.bucketName = bucketName;
+        this.s3ProxyUrl = s3ProxyUrl;
+        this.s3Url = s3Url;
+        this.client = client;
+        if (s3InitialConnectionTest) {
+            this.initialConnectionTest(bucketName, client);
+        }
     }
-  }
 
-  /**
-   * Returns the paths to the files in a given folder.
-   *
-   * @param folder The folder.
-   *               The path must be absolute and without specifying the bucket.
-   *               Example 1:
-   *               Folder in bucket: "BUCKET/folder"
-   *               Specification in parameter: "folder"
-   *               Example 2:
-   *               Folder in bucket: "BUCKET/folder/subfolder"
-   *               Specification in parameter: "folder/subfolder"
-   * @return the paths to the files in a given folder. Also returns the paths to the files in subfolders.
-   * @throws FileSystemAccessException if the paths cannot be downloaded.
-   */
-  public Set<String> getFilePathsFromFolder(final String folder) throws FileSystemAccessException {
-    try {
-      final ListObjectsArgs listObjectsArgs = ListObjectsArgs.builder()
-          .bucket(this.bucketName)
-          .prefix(folder)
-          .recursive(true)
-          .build();
-      final List<Result<Item>> resultItemList = IteratorUtils.toList(this.client.listObjects(listObjectsArgs).iterator());
-      final Set<String> filepathesFromFolder = new HashSet<>();
-      for (final Result<Item> resultItem : resultItemList) {
-        filepathesFromFolder.add(resultItem.get().objectName());
-      }
-      return filepathesFromFolder;
-    } catch (final MinioException | InvalidKeyException | NoSuchAlgorithmException | IllegalArgumentException |
-                   IOException exception) {
-      final String message = String.format("Failed to extract file paths from folder %s.", folder);
-      log.error(message, exception);
-      throw new FileSystemAccessException(message, exception);
+    public boolean fileExists(final String path) throws FileSystemAccessException {
+        try {
+            client.statObject(StatObjectArgs.builder()
+                    .bucket(bucketName).object(path).build());
+        } catch (final ErrorResponseException errorResponseException) {
+            if ("NoSuchKey".equals(errorResponseException.errorResponse().code())) return false;
+            else new FileSystemAccessException(errorResponseException.errorResponse().code(), errorResponseException);
+        } catch (InsufficientDataException | InternalException | InvalidKeyException | InvalidResponseException | IOException |
+                NoSuchAlgorithmException | ServerException | XmlParserException exception) {
+            final String message = String.format("Failed to request metadata for file %s.", path);
+            log.error(message, exception);
+            throw new FileSystemAccessException(message, exception);
+        }
+        return true;
     }
-  }
 
-  /**
-   * Deletes the file given in the parameter.
-   *
-   * @param pathToFile The path to the file.
-   *                   The path must be absolute and without specifying the bucket.
-   *                   Example:
-   *                   File in bucket: "BUCKET/outerFolder/innerFolder/thefile.csv"
-   *                   Specification in parameter: "outerFolder/innerFolder/thefile.csv"
-   * @throws FileSystemAccessException if the file cannot be deleted.
-   */
-  public void deleteFile(final String pathToFile) throws FileSystemAccessException {
-    try {
-      final RemoveObjectArgs removeObjectArgs = RemoveObjectArgs.builder()
-          .bucket(this.bucketName)
-          .object(pathToFile)
-          .build();
-      this.client.removeObject(removeObjectArgs);
-    } catch (final InvalidKeyException | ErrorResponseException | InsufficientDataException | InternalException
-                   | InvalidResponseException | NoSuchAlgorithmException | ServerException | XmlParserException
-                   | IllegalArgumentException | IOException exception) {
-      final String message = String.format("Failed to delete file %s.", pathToFile);
-      log.error(message, exception);
-      throw new FileSystemAccessException(message, exception);
+    /**
+     * Returns the paths to the files in a given folder.
+     *
+     * @param folder The folder. The path must be absolute and without specifying the bucket. Example 1: Folder in bucket: "BUCKET/folder" Specification in
+     *               parameter: "folder" Example 2: Folder in bucket: "BUCKET/folder/subfolder" Specification in parameter: "folder/subfolder"
+     * @return the paths to the files in a given folder. Also returns the paths to the files in subfolders.
+     * @throws FileSystemAccessException if the paths cannot be downloaded.
+     */
+    public Set<String> getFilePathsFromFolder(final String folder) throws FileSystemAccessException {
+        try {
+            final ListObjectsArgs listObjectsArgs = ListObjectsArgs.builder()
+                    .bucket(this.bucketName)
+                    .prefix(folder)
+                    .recursive(true)
+                    .build();
+            final List<Result<Item>> resultItemList = IteratorUtils.toList(this.client.listObjects(listObjectsArgs).iterator());
+            final Set<String> filepathesFromFolder = new HashSet<>();
+            for (final Result<Item> resultItem : resultItemList) {
+                filepathesFromFolder.add(resultItem.get().objectName());
+            }
+            return filepathesFromFolder;
+        } catch (final MinioException | InvalidKeyException | NoSuchAlgorithmException | IllegalArgumentException |
+                IOException exception) {
+            final String message = String.format("Failed to extract file paths from folder %s.", folder);
+            log.error(message, exception);
+            throw new FileSystemAccessException(message, exception);
+        }
     }
-  }
 
-  /**
-   * Creates the presigned URL fora file to the given file path.
-   *
-   * @param pathToFile       The path to the file.
-   *                         The path must be absolute and without specifying the bucket.
-   *                         Example:
-   *                         File in bucket: "BUCKET/outerFolder/innerFolder/thefile.csv"
-   *                         Specification in parameter: "outerFolder/innerFolder/thefile.csv"
-   * @param action           to determine the file permissions.
-   * @param expiresInMinutes to define the validity period of the presigned URL.
-   * @return the presigned URL for a file.
-   * @throws FileSystemAccessException if the presigned URL cannot be created.
-   */
-  public String getPresignedUrl(final String pathToFile, final Method action, final int expiresInMinutes) throws FileSystemAccessException {
-    try {
-      final GetPresignedObjectUrlArgs presignedUrlArgs = GetPresignedObjectUrlArgs.builder()
-          .method(action)
-          .bucket(this.bucketName)
-          .object(pathToFile)
-          .expiry(expiresInMinutes, TimeUnit.MINUTES)
-          .build();
-      final String presignedUrl = this.client.getPresignedObjectUrl(presignedUrlArgs);
-      // use proxy if enabled
-      return this.s3ProxyUrl.map(proxy -> presignedUrl.replaceFirst(this.s3Url, proxy)).orElse(presignedUrl);
-    } catch (final InvalidKeyException | ErrorResponseException | InsufficientDataException | InternalException
-                   | InvalidResponseException | NoSuchAlgorithmException | ServerException | XmlParserException
-                   | IllegalArgumentException | IOException exception) {
-      final String message = String.format("Failed to create presigned url for file %s. in mode %s", pathToFile, action);
-      log.error(message, exception);
-      throw new FileSystemAccessException(message, exception);
+    /**
+     * Deletes the file given in the parameter.
+     *
+     * @param pathToFile The path to the file. The path must be absolute and without specifying the bucket. Example: File in bucket:
+     *                   "BUCKET/outerFolder/innerFolder/thefile.csv" Specification in parameter: "outerFolder/innerFolder/thefile.csv"
+     * @throws FileSystemAccessException if the file cannot be deleted.
+     */
+    public void deleteFile(final String pathToFile) throws FileSystemAccessException {
+        try {
+            final RemoveObjectArgs removeObjectArgs = RemoveObjectArgs.builder()
+                    .bucket(this.bucketName)
+                    .object(pathToFile)
+                    .build();
+            this.client.removeObject(removeObjectArgs);
+        } catch (final InvalidKeyException | ErrorResponseException | InsufficientDataException | InternalException
+                | InvalidResponseException | NoSuchAlgorithmException | ServerException | XmlParserException
+                | IllegalArgumentException | IOException exception) {
+            final String message = String.format("Failed to delete file %s.", pathToFile);
+            log.error(message, exception);
+            throw new FileSystemAccessException(message, exception);
+        }
     }
-  }
 
-  /**
-   * Performs an initial connection test against the S3 storage.
-   *
-   * @param bucketName to which this Repository should connect.
-   * @param client     to communicate with the s3 storage.
-   * @throws FileSystemAccessException if the initial connection test fails.
-   */
-  private void initialConnectionTest(final String bucketName, final MinioClient client) throws FileSystemAccessException {
-    try {
-      final boolean bucketExists = client.bucketExists(BucketExistsArgs.builder().bucket(bucketName).build());
-      if (!bucketExists) {
-        final String message = "S3 bucket does not exist.";
-        log.error(message);
-        throw new FileSystemAccessException(message);
-      }
-    } catch (final MinioException | InvalidKeyException | NoSuchAlgorithmException | IllegalArgumentException |
-                   IOException exception) {
-      final String message = "S3 initialization failed.";
-      log.error(message, exception);
-      throw new FileSystemAccessException(message, exception);
+    /**
+     * Creates the presigned URL fora file to the given file path.
+     *
+     * @param pathToFile       The path to the file. The path must be absolute and without specifying the bucket. Example: File in bucket:
+     *                         "BUCKET/outerFolder/innerFolder/thefile.csv" Specification in parameter: "outerFolder/innerFolder/thefile.csv"
+     * @param action           to determine the file permissions.
+     * @param expiresInMinutes to define the validity period of the presigned URL.
+     * @return the presigned URL for a file.
+     * @throws FileSystemAccessException if the presigned URL cannot be created.
+     */
+    public String getPresignedUrl(final String pathToFile, final Method action, final int expiresInMinutes) throws FileSystemAccessException {
+        try {
+            final GetPresignedObjectUrlArgs presignedUrlArgs = GetPresignedObjectUrlArgs.builder()
+                    .method(action)
+                    .bucket(this.bucketName)
+                    .object(pathToFile)
+                    .expiry(expiresInMinutes, TimeUnit.MINUTES)
+                    .build();
+            final String presignedUrl = this.client.getPresignedObjectUrl(presignedUrlArgs);
+            // use proxy if enabled
+            return this.s3ProxyUrl.map(proxy -> presignedUrl.replaceFirst(this.s3Url, proxy)).orElse(presignedUrl);
+        } catch (final InvalidKeyException | ErrorResponseException | InsufficientDataException | InternalException
+                | InvalidResponseException | NoSuchAlgorithmException | ServerException | XmlParserException
+                | IllegalArgumentException | IOException exception) {
+            final String message = String.format("Failed to create presigned url for file %s. in mode %s", pathToFile, action);
+            log.error(message, exception);
+            throw new FileSystemAccessException(message, exception);
+        }
     }
-  }
+
+    /**
+     * Performs an initial connection test against the S3 storage.
+     *
+     * @param bucketName to which this Repository should connect.
+     * @param client     to communicate with the s3 storage.
+     * @throws FileSystemAccessException if the initial connection test fails.
+     */
+    private void initialConnectionTest(final String bucketName, final MinioClient client) throws FileSystemAccessException {
+        try {
+            final boolean bucketExists = client.bucketExists(BucketExistsArgs.builder().bucket(bucketName).build());
+            if (!bucketExists) {
+                final String message = "S3 bucket does not exist.";
+                log.error(message);
+                throw new FileSystemAccessException(message);
+            }
+        } catch (final MinioException | InvalidKeyException | NoSuchAlgorithmException | IllegalArgumentException |
+                IOException exception) {
+            final String message = "S3 initialization failed.";
+            log.error(message, exception);
+            throw new FileSystemAccessException(message, exception);
+        }
+    }
 
 }

--- a/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-core/src/main/java/de/muenchen/oss/digiwf/s3/integration/adapter/out/s3/S3Repository.java
+++ b/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-core/src/main/java/de/muenchen/oss/digiwf/s3/integration/adapter/out/s3/S3Repository.java
@@ -20,6 +20,9 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 public class S3Repository {
 
+    /** Response code from S3 storage when an object cannot be found. */
+    private static final String RESPONSE_CODE_NO_SUCH_KEY = "NoSuchKey";
+
     private final String bucketName;
     private final String s3Url;
     private final Optional<String> s3ProxyUrl;
@@ -49,13 +52,20 @@ public class S3Repository {
         }
     }
 
+    /**
+     * Checks whether a file exists in the specified path.
+     *
+     * @param path the path of the file to be checked
+     * @return true if the file exists, false otherwise
+     * @throws FileSystemAccessException if there is an exception while accessing the file system
+     */
     public boolean fileExists(final String path) throws FileSystemAccessException {
         try {
             client.statObject(StatObjectArgs.builder()
                     .bucket(bucketName).object(path).build());
         } catch (final ErrorResponseException errorResponseException) {
-            if ("NoSuchKey".equals(errorResponseException.errorResponse().code())) return false;
-            else new FileSystemAccessException(errorResponseException.errorResponse().code(), errorResponseException);
+            if (RESPONSE_CODE_NO_SUCH_KEY.equals(errorResponseException.errorResponse().code())) return false;
+            else throw new FileSystemAccessException(errorResponseException.errorResponse().code(), errorResponseException);
         } catch (InsufficientDataException | InternalException | InvalidKeyException | InvalidResponseException | IOException |
                 NoSuchAlgorithmException | ServerException | XmlParserException exception) {
             final String message = String.format("Failed to request metadata for file %s.", path);

--- a/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-core/src/main/java/de/muenchen/oss/digiwf/s3/integration/adapter/out/s3/S3Repository.java
+++ b/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-core/src/main/java/de/muenchen/oss/digiwf/s3/integration/adapter/out/s3/S3Repository.java
@@ -78,8 +78,14 @@ public class S3Repository {
     /**
      * Returns the paths to the files in a given folder.
      *
-     * @param folder The folder. The path must be absolute and without specifying the bucket. Example 1: Folder in bucket: "BUCKET/folder" Specification in
-     *               parameter: "folder" Example 2: Folder in bucket: "BUCKET/folder/subfolder" Specification in parameter: "folder/subfolder"
+     * @param folder The folder.
+     *               The path must be absolute and without specifying the bucket.
+     *               Example 1:
+     *               Folder in bucket: "BUCKET/folder"
+     *               Specification in parameter: "folder"
+     *               Example 2:
+     *               Folder in bucket: "BUCKET/folder/subfolder"
+     *               Specification in parameter: "folder/subfolder"
      * @return the paths to the files in a given folder. Also returns the paths to the files in subfolders.
      * @throws FileSystemAccessException if the paths cannot be downloaded.
      */
@@ -107,8 +113,11 @@ public class S3Repository {
     /**
      * Deletes the file given in the parameter.
      *
-     * @param pathToFile The path to the file. The path must be absolute and without specifying the bucket. Example: File in bucket:
-     *                   "BUCKET/outerFolder/innerFolder/thefile.csv" Specification in parameter: "outerFolder/innerFolder/thefile.csv"
+     * @param pathToFile The path to the file.
+     *                   The path must be absolute and without specifying the bucket.
+     *                   Example:
+     *                   File in bucket: "BUCKET/outerFolder/innerFolder/thefile.csv"
+     *                   Specification in parameter: "outerFolder/innerFolder/thefile.csv"
      * @throws FileSystemAccessException if the file cannot be deleted.
      */
     public void deleteFile(final String pathToFile) throws FileSystemAccessException {
@@ -130,8 +139,11 @@ public class S3Repository {
     /**
      * Creates the presigned URL fora file to the given file path.
      *
-     * @param pathToFile       The path to the file. The path must be absolute and without specifying the bucket. Example: File in bucket:
-     *                         "BUCKET/outerFolder/innerFolder/thefile.csv" Specification in parameter: "outerFolder/innerFolder/thefile.csv"
+     * @param pathToFile       The path to the file.
+     *                         The path must be absolute and without specifying the bucket.
+     *                         Example:
+     *                         File in bucket: "BUCKET/outerFolder/innerFolder/thefile.csv"
+     *                         Specification in parameter: "outerFolder/innerFolder/thefile.csv"
      * @param action           to determine the file permissions.
      * @param expiresInMinutes to define the validity period of the presigned URL.
      * @return the presigned URL for a file.

--- a/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-core/src/main/java/de/muenchen/oss/digiwf/s3/integration/application/CleanUpDatabaseFilesWithoutCorrespondingS3FolderUseCase.java
+++ b/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-core/src/main/java/de/muenchen/oss/digiwf/s3/integration/application/CleanUpDatabaseFilesWithoutCorrespondingS3FolderUseCase.java
@@ -46,9 +46,7 @@ public class CleanUpDatabaseFilesWithoutCorrespondingS3FolderUseCase implements 
   boolean shouldDatabaseFileBeDeleted(final File file) {
     boolean deleteDatabaseFile = false;
     try {
-      final String pathToFolder = FileOperationsUseCase.getPathToFolder(file.getPathToFile());
-      final Set<String> pathToFiles = this.s3Repository.getFilePathsFromFolder(pathToFolder);
-      final boolean noSuchFileExistsInS3 = !pathToFiles.contains(file.getPathToFile());
+      final boolean noSuchFileExistsInS3 = !this.s3Repository.fileExists(file.getPathToFile());
       final LocalDate creationDate = file.getCreatedTime().toLocalDate();
       final boolean folderCreatedMoreThanAMonthAgo = creationDate.isBefore(LocalDate.now().minusMonths(1));
       deleteDatabaseFile = noSuchFileExistsInS3 && folderCreatedMoreThanAMonthAgo;

--- a/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-core/src/main/java/de/muenchen/oss/digiwf/s3/integration/application/FileOperationsUseCase.java
+++ b/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-core/src/main/java/de/muenchen/oss/digiwf/s3/integration/application/FileOperationsUseCase.java
@@ -195,10 +195,7 @@ public class FileOperationsUseCase implements FileOperationsInPort {
   }
 
   private boolean fileExists(final String filePath) throws FileSystemAccessException {
-    final String pathToFolder = getPathToFolder(filePath);
-    final Set<String> filePathsInFolder = this.s3Repository.getFilePathsFromFolder(pathToFolder);
-    // if file does not exist throw an error
-    return filePathsInFolder.contains(filePath);
+    return this.s3Repository.fileExists(filePath);
   }
 
   /**

--- a/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-core/src/test/java/de/muenchen/oss/digiwf/s3/integration/application/CleanUpDatabaseFilesWithoutCorrespondingS3FolderUseCaseTest.java
+++ b/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-core/src/test/java/de/muenchen/oss/digiwf/s3/integration/application/CleanUpDatabaseFilesWithoutCorrespondingS3FolderUseCaseTest.java
@@ -43,21 +43,22 @@ class CleanUpDatabaseFilesWithoutCorrespondingS3FolderUseCaseTest {
 
     // Creation date is more than one month ago.
     file.setCreatedTime(LocalDateTime.now().minusMonths(1).minusDays(1));
-    Mockito.when(this.s3Repository.getFilePathsFromFolder("folder"))
-        .thenReturn(new HashSet<>(List.of(file.getPathToFile())));
+    Mockito.when(this.s3Repository.fileExists(file.getPathToFile()))
+        .thenReturn(true);
     assertThat(this.cleanUpDatabaseFolderWithoutCorrespondingS3Folder.shouldDatabaseFileBeDeleted(file)).isFalse();
-    Mockito.when(this.s3Repository.getFilePathsFromFolder("folder"))
-        .thenReturn(new HashSet<>(List.of()));
+
+    Mockito.when(this.s3Repository.fileExists(file.getPathToFile()))
+            .thenReturn(false);
     assertThat(this.cleanUpDatabaseFolderWithoutCorrespondingS3Folder.shouldDatabaseFileBeDeleted(file)).isTrue();
 
     // Creation date is exactly one month or less ago.
     file.setCreatedTime(LocalDateTime.now().minusMonths(1));
-    Mockito.when(this.s3Repository.getFilePathsFromFolder("folder"))
-        .thenReturn(new HashSet<>(List.of(file.getPathToFile())));
+    Mockito.when(this.s3Repository.fileExists(file.getPathToFile()))
+            .thenReturn(true);
     assertThat(this.cleanUpDatabaseFolderWithoutCorrespondingS3Folder.shouldDatabaseFileBeDeleted(file)).isFalse();
 
-    Mockito.when(this.s3Repository.getFilePathsFromFolder("folder"))
-        .thenReturn(new HashSet<>(List.of()));
+    Mockito.when(this.s3Repository.fileExists(file.getPathToFile()))
+            .thenReturn(false);
     assertThat(this.cleanUpDatabaseFolderWithoutCorrespondingS3Folder.shouldDatabaseFileBeDeleted(file)).isFalse();
   }
 

--- a/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-core/src/test/java/de/muenchen/oss/digiwf/s3/integration/application/FileOperationsUseCaseTest.java
+++ b/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-core/src/test/java/de/muenchen/oss/digiwf/s3/integration/application/FileOperationsUseCaseTest.java
@@ -82,6 +82,7 @@ class FileOperationsUseCaseTest {
     actions.forEach(action -> {
       try {
         Mockito.when(this.s3Repository.fileExists(pathToFile)).thenReturn(true);
+        Mockito.when(this.s3Repository.getFilePathsFromFolder(pathToFile)).thenReturn(Set.of(pathToFile));
         Mockito.when(this.s3Repository.getPresignedUrl(pathToFile, action, expiresInMinutes)).thenReturn(examplePresignedUrl);
 
         final List<PresignedUrl> presignedUrls = this.fileOperations.getPresignedUrls(List.of(pathToFile), action, expiresInMinutes);
@@ -218,6 +219,7 @@ class FileOperationsUseCaseTest {
     final int expiresInMinutes = 5;
     final String presignedUrl = "THE_PRESIGNED_URL";
 
+    Mockito.when(this.s3Repository.fileExists(pathToFile)).thenReturn(true);
     Mockito.when(this.s3Repository.getFilePathsFromFolder(pathToFolder)).thenReturn(new HashSet<>(List.of(pathToFile)));
     Mockito.when(this.s3Repository.getPresignedUrl(pathToFile, Method.GET, expiresInMinutes)).thenReturn(presignedUrl);
 
@@ -238,6 +240,7 @@ class FileOperationsUseCaseTest {
     fileData.setPathToFile(pathToFile);
     fileData.setExpiresInMinutes(5);
 
+    Mockito.when(this.s3Repository.fileExists(pathToFile)).thenReturn(true);
     Mockito.when(this.s3Repository.getFilePathsFromFolder(pathToFolder)).thenReturn(new HashSet<>(List.of(pathToFile)));
     Assertions.assertThrows(FileExistenceException.class, () -> this.fileOperations.saveFile(fileData));
     // happy path is tested in updateFile
@@ -336,10 +339,10 @@ class FileOperationsUseCaseTest {
     final int expiresInMinutes = 5;
 
     Mockito.reset(this.s3Repository);
-    Mockito.when(this.s3Repository.getFilePathsFromFolder(pathToFolder)).thenReturn(new HashSet<>(List.of(pathToFile)));
+    Mockito.when(this.s3Repository.fileExists(pathToFile)).thenReturn(true);
     this.fileOperations.deleteFile(pathToFile, expiresInMinutes);
     Mockito.verify(this.s3Repository, Mockito.times(1)).getPresignedUrl(pathToFile, Method.DELETE, expiresInMinutes);
-    Mockito.verify(this.s3Repository, Mockito.times(1)).getFilePathsFromFolder(pathToFolder);
+    Mockito.verify(this.s3Repository, Mockito.times(1)).fileExists(pathToFile);
   }
 
   @Test

--- a/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-core/src/test/java/de/muenchen/oss/digiwf/s3/integration/application/FileOperationsUseCaseTest.java
+++ b/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-core/src/test/java/de/muenchen/oss/digiwf/s3/integration/application/FileOperationsUseCaseTest.java
@@ -81,7 +81,7 @@ class FileOperationsUseCaseTest {
     // GET, PUT, DELETE
     actions.forEach(action -> {
       try {
-        Mockito.when(this.s3Repository.getFilePathsFromFolder(pathToFile)).thenReturn(Set.of(pathToFile));
+        Mockito.when(this.s3Repository.fileExists(pathToFile)).thenReturn(true);
         Mockito.when(this.s3Repository.getPresignedUrl(pathToFile, action, expiresInMinutes)).thenReturn(examplePresignedUrl);
 
         final List<PresignedUrl> presignedUrls = this.fileOperations.getPresignedUrls(List.of(pathToFile), action, expiresInMinutes);


### PR DESCRIPTION
### Description
<!-- Brief explanation of the changes and their impact -->
Neue Methode `S3Repository.fileExists` für die Prüfung, die Vorhandensein eines Dateiobjekts im S3-Storage prüft, ohne den gesamten Ornderinhalt abzufragen.

### Reference

Issues: #1480

### Screenshots (If UI changed)


### Check-List

- [x] All Acceptance criteria of user story are met
- [x] Accessibility was considered and tested (On UI Change)
- [x] JUnit tests are written (60% CodeCov)
- [x] [Internal Review]([https://github.com/it-at-m/digiwf-core/blob/dev/CHANGELOG.md](https://confluence.muenchen.de/display/MPdZ/Review+-+DigiWF)) is maintained
<del>- [ ] Documentations [external](https://github.com/it-at-m/digiwf-core/tree/dev/docs) and [internal](https://wiki.muenchen.de/betriebshandbuch/index.php?title=DigiWF&sfr=betriebshandbuch) are completed</del>
- [x] Smoketest successful (Manual E2E-Test depending on Change) 
- [x] No waste on Branch left (e.g. `console.logs`)
- [x] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
<del>- [ ] Openshift environments are prepared (Secrets, etc.) and release-issue is maintained</del>
