### PR TITLE
stack fix keycloak init

### DIFF
--- a/stack/keycloak/keycloak-changelog.yml
+++ b/stack/keycloak/keycloak-changelog.yml
@@ -12,4 +12,3 @@ includes:
   - path: 10_johndoe.yml
   - path: 11_johndoe_webapp.yml
   - path: 12_janedoe.yml
-  - path: 13_process_cleanup.yml


### PR DESCRIPTION
### Description
<!-- Brief explanation of the changes and their impact -->

Fix stack keycloak init from difference between #1537 and #1445

### Check-List

- [x] Smoketest successful (Manual E2E-Test depending on Change) 
- [x] No waste on Branch left (e.g. `console.logs`)
