### PR TITLE
camunda prometheus task metrics also include suspended

### DIFF
--- a/digiwf-libs/digiwf-camunda-prometheus/digiwf-camunda-prometheus-core/src/main/java/de/muenchen/oss/digiwf/camunda/prometheus/TaskMetricsProvider.java
+++ b/digiwf-libs/digiwf-camunda-prometheus/digiwf-camunda-prometheus-core/src/main/java/de/muenchen/oss/digiwf/camunda/prometheus/TaskMetricsProvider.java
@@ -14,12 +14,12 @@ public class TaskMetricsProvider implements MetricsProvider {
 
     @Override
     public void updateMetrics() {
-        this.openTasks.labels("assigned").set(this.taskService.createTaskQuery().active().taskAssigned().count());
-        this.openTasks.labels("unassigned").set(this.taskService.createTaskQuery().active().taskUnassigned().count());
-        this.openTasks.labels("hasCandidateGroups").set(this.taskService.createTaskQuery().active().withCandidateGroups().count());
-        this.openTasks.labels("hasCandidateUsers").set(this.taskService.createTaskQuery().active().withCandidateUsers().count());
-        this.openTasks.labels("unassignedWithNoCandidates").set(this.taskService.createTaskQuery().active().taskUnassigned().withoutCandidateGroups().withoutCandidateUsers().count());
-        this.openTasks.labels("total").set(this.taskService.createTaskQuery().active().count());
+        this.openTasks.labels("assigned").set(this.taskService.createTaskQuery().taskAssigned().count());
+        this.openTasks.labels("unassigned").set(this.taskService.createTaskQuery().taskUnassigned().count());
+        this.openTasks.labels("hasCandidateGroups").set(this.taskService.createTaskQuery().withCandidateGroups().count());
+        this.openTasks.labels("hasCandidateUsers").set(this.taskService.createTaskQuery().withCandidateUsers().count());
+        this.openTasks.labels("unassignedWithNoCandidates").set(this.taskService.createTaskQuery().taskUnassigned().withoutCandidateGroups().withoutCandidateUsers().count());
+        this.openTasks.labels("total").set(this.taskService.createTaskQuery().count());
     }
 
     @Override


### PR DESCRIPTION
### Description
<!-- Brief explanation of the changes and their impact -->

Camunda prometheus metrics rm `active` from task metrics to match cockpit ui.

### Check-List

- [x] No waste on Branch left (e.g. `console.logs`)
- [x] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
