### PR TITLE
Bugfix/fix engine metrics tasks

### DIFF
--- a/digiwf-libs/digiwf-camunda-prometheus/digiwf-camunda-prometheus-core/src/main/java/de/muenchen/oss/digiwf/camunda/prometheus/TaskMetricsProvider.java
+++ b/digiwf-libs/digiwf-camunda-prometheus/digiwf-camunda-prometheus-core/src/main/java/de/muenchen/oss/digiwf/camunda/prometheus/TaskMetricsProvider.java
@@ -19,6 +19,8 @@ public class TaskMetricsProvider implements MetricsProvider {
         this.openTasks.labels("hasCandidateGroups").set(this.taskService.createTaskQuery().withCandidateGroups().count());
         this.openTasks.labels("hasCandidateUsers").set(this.taskService.createTaskQuery().withCandidateUsers().count());
         this.openTasks.labels("unassignedWithNoCandidates").set(this.taskService.createTaskQuery().taskUnassigned().withoutCandidateGroups().withoutCandidateUsers().count());
+        this.openTasks.labels("suspended").set(this.taskService.createTaskQuery().suspended().count());
+        this.openTasks.labels("active").set(this.taskService.createTaskQuery().active().count());
         this.openTasks.labels("total").set(this.taskService.createTaskQuery().count());
     }
 


### PR DESCRIPTION
### Description
<!-- Brief explanation of the changes and their impact -->
Camunda prometheus metrics rm active from task metrics to match cockpit ui and add new status `suspended` and `active`

- [x] No waste on Branch left (e.g. `console.logs`)
- [x] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
