### PR TITLE
allow ALW integration test to autocreate topics

### DIFF
--- a/digiwf-integrations/digiwf-alw-integration/digiwf-alw-integration-service/src/test/resources/application-mocked-alw-service.yml
+++ b/digiwf-integrations/digiwf-alw-integration/digiwf-alw-integration-service/src/test/resources/application-mocked-alw-service.yml
@@ -15,3 +15,9 @@ io:
         incidentDestination: "dwf-connector-incident-itest-01"
         bpmnErrorDestination: "dwf-connector-bpmnerror-itest-01"
         correlateMessageDestination: "dwf-connector-itest-01"
+spring:
+  cloud:
+    stream:
+      kafka:
+        binder:
+          auto-create-topics: 'true'


### PR DESCRIPTION
### Description
<!-- Brief explanation of the changes and their impact -->
Allows ALW integration test to autocreate topics because it needs to.

### Reference

### Screenshots (If UI changed)


### Check-List

- [x] All Acceptance criteria of user story are met
- [x] Accessibility was considered and tested (On UI Change)
- [x] JUnit tests are written (60% CodeCov)
- [x] [Internal Review]([https://github.com/it-at-m/digiwf-core/blob/dev/CHANGELOG.md](https://confluence.muenchen.de/display/MPdZ/Review+-+DigiWF)) is maintained
- [x] Documentations [external](https://github.com/it-at-m/digiwf-core/tree/dev/docs) and [internal](https://wiki.muenchen.de/betriebshandbuch/index.php?title=DigiWF&sfr=betriebshandbuch) are completed
- [x] Smoketest successful (Manual E2E-Test depending on Change)
- [x] No waste on Branch left (e.g. `console.logs`)
- [x] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
- [x] Internal Services / Artifacts updated (Depending on Change - See Dependency Graph)
- [x] Openshift environments are prepared (Secrets, etc.) and release-issue is maintained
