### PR TITLE
Bugfix/1664 zeilenumbrüche in e mail template mit logo und link funktionieren nicht

### DIFF
--- a/digiwf-integrations/digiwf-email-integration/digiwf-email-integration-service/src/main/resources/templates/mail-template.ftl
+++ b/digiwf-integrations/digiwf-email-integration/digiwf-email-integration-service/src/main/resources/templates/mail-template.ftl
@@ -166,7 +166,7 @@
         <!-- 1 Column Text : BEGIN -->
         <tr>
             <td style="padding: 40px; font-family: sans-serif; font-size: 15px; mso-height-rule: exactly; line-height: 20px; color: #555555;">
-                ${mail.text}
+                ${mail.text?replace('(\\r\\n|\\n\\r|\\r|\\n)', '<br>', 'r')}
                 <#if mail.buttonLink?has_content && mail.buttonText?has_content>
                     <br><br><br>
                     <!-- Button : Begin -->
@@ -181,8 +181,8 @@
                     </table>
                     <!-- Button : END -->
                 </#if>
-                <br /><br />
-                ${mail.bottomBody}
+                <br><br>
+                ${mail.bottomBody?replace('(\\r\\n|\\n\\r|\\r|\\n)', '<br>', 'r')}
             </td>
         </tr>
         <!-- 1 Column Text : BEGIN -->

--- a/docs/src/modeling/bausteine/README.md
+++ b/docs/src/modeling/bausteine/README.md
@@ -24,5 +24,5 @@ Call Activity modelliert, so schlägt der Modeller alle verfügbaren Element-Tem
 Die DigiWF-Plattform stellt verschiedene Element-Templates bereit, die die Modellierung von häufig benötigten Features
 vereinfachen.
 
-Eine Liste aller Templates ist unter [Element-Templates](http://localhost:8099/modeling/templates/element-templates/)
+Eine Liste aller Templates ist unter [Element-Templates](../templates/element-templates/index.md)
 verfügbar.

--- a/docs/src/modeling/bausteine/integrationen/index.md
+++ b/docs/src/modeling/bausteine/integrationen/index.md
@@ -63,7 +63,9 @@ Um eine einfache E-Mail zu versenden, wird das Element Template `Mail: E-Mail se
 
 ### E-Mail mit Logo versenden
 
-Um eine E-Mail mit Logo zu versenden, wird das Element Template `Mail: E-Mail mit Logo senden` verwendet.
+Um eine E-Mail mit Logo zu versenden, wird das Element Template `Mail: E-Mail mit Logo senden` verwendet. Bei der Verwendung ist zu beachten, 
+dass Zeilenumbrüche in den Werten der Felder 'E-Mail Text' und 'E-Mail Gruß' durch `<br>` ersetzt werden, damit sie in der als HTML 
+zugestellten E-Mail korrekt angezeigt werden.
 
 **Properties**
 
@@ -80,7 +82,9 @@ Um eine E-Mail mit Logo zu versenden, wird das Element Template `Mail: E-Mail mi
 
 ### E-Mail mit Logo und Link versenden
 
-Um eine E-Mail mit Logo zu versenden, wird das Element Template `Mail: E-Mail mit Logo und Link senden` verwendet.
+Um eine E-Mail mit Logo zu versenden, wird das Element Template `Mail: E-Mail mit Logo und Link senden` verwendet. Bei der Verwendung ist zu 
+beachten, dass Zeilenumbrüche in den Werten der Felder 'E-Mail Text' und 'E-Mail Gruß' durch `<br>` ersetzt werden, damit sie in der als 
+HTML zugestellten E-Mail korrekt angezeigt werden.
 
 **Properties**
 


### PR DESCRIPTION
### Description
<!-- Brief explanation of the changes and their impact -->

### Reference

Issues: #1664 

### Screenshots (If UI changed)


### Check-List

- [x] All Acceptance criteria of user story are met
- [x] Accessibility was considered and tested (On UI Change)
- [ ] ~~JUnit tests are written (60% CodeCov)~~
- [ ] [Internal Review]([https://github.com/it-at-m/digiwf-core/blob/dev/CHANGELOG.md](https://confluence.muenchen.de/display/MPdZ/Review+-+DigiWF)) is maintained
- [x] Documentations [external](https://github.com/it-at-m/digiwf-core/tree/dev/docs) and [internal](https://wiki.muenchen.de/betriebshandbuch/index.php?title=DigiWF&sfr=betriebshandbuch) are completed
- [x] Smoketest successful (Manual E2E-Test depending on Change)
- [x] No waste on Branch left (e.g. `console.logs`)
- [x] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
- [x] Internal Services / Artifacts updated (Depending on Change - See Dependency Graph)
- [x] Openshift environments are prepared (Secrets, etc.) and release-issue is maintained
