### PR TITLE
chore: bump release version bump-1.12.0 (#1689)

### DIFF
--- a/digiwf-apps/lerna.json
+++ b/digiwf-apps/lerna.json
@@ -13,5 +13,5 @@
     "packages/apps/digiwf-tasklist",
     "packages/apps/digiwf-webcomponent"
   ],
-  "version": "1.11.0"
+  "version": "1.12.0"
 }

--- a/digiwf-apps/packages/apps/digiwf-forms-example/package-lock.json
+++ b/digiwf-apps/packages/apps/digiwf-forms-example/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@muenchen/digiwf-forms-example",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@muenchen/digiwf-forms-example",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "dependencies": {
         "@muenchen/vjsf": "^2.21.14",
         "vue": "^2.7.10",

--- a/digiwf-apps/packages/apps/digiwf-forms-example/package.json
+++ b/digiwf-apps/packages/apps/digiwf-forms-example/package.json
@@ -2,18 +2,18 @@
   "name": "@muenchen/digiwf-forms-example",
   "description": "DigiWF Forms",
   "private": true,
-  "version": "1.11.0",
+  "version": "1.12.0",
   "scripts": {
     "dev": "vite --host localhost",
     "build": "vite build"
   },
   "dependencies": {
-    "@muenchen/digiwf-date-input": "^1.11.0",
-    "@muenchen/digiwf-dms-input": "^1.11.0",
-    "@muenchen/digiwf-form-builder": "^1.11.0",
-    "@muenchen/digiwf-form-builder-settings": "^1.11.0",
-    "@muenchen/digiwf-form-renderer": "^1.11.0",
-    "@muenchen/digiwf-multi-file-input": "^1.11.0",
+    "@muenchen/digiwf-date-input": "^1.12.0",
+    "@muenchen/digiwf-dms-input": "^1.12.0",
+    "@muenchen/digiwf-form-builder": "^1.12.0",
+    "@muenchen/digiwf-form-builder-settings": "^1.12.0",
+    "@muenchen/digiwf-form-renderer": "^1.12.0",
+    "@muenchen/digiwf-multi-file-input": "^1.12.0",
     "@muenchen/vjsf": "^2.21.14",
     "vue": "^2.7.10",
     "vuetify": "^2.6.9"

--- a/digiwf-apps/packages/apps/digiwf-tasklist/package-lock.json
+++ b/digiwf-apps/packages/apps/digiwf-tasklist/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@muenchen/digiwf-tasklist",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@muenchen/digiwf-tasklist",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "dependencies": {
         "@jamescoyle/vue-icon": "^0.1.2",
         "@mdi/js": "^7.3.67",

--- a/digiwf-apps/packages/apps/digiwf-tasklist/package.json
+++ b/digiwf-apps/packages/apps/digiwf-tasklist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muenchen/digiwf-tasklist",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "private": true,
   "scripts": {
     "dev": "vite",
@@ -11,13 +11,13 @@
   "dependencies": {
     "@jamescoyle/vue-icon": "^0.1.2",
     "@mdi/js": "^7.3.67",
-    "@muenchen/digiwf-date-input": "^1.11.0",
-    "@muenchen/digiwf-dms-api-internal": "^1.11.0",
-    "@muenchen/digiwf-dms-input": "^1.11.0",
-    "@muenchen/digiwf-engine-api-internal": "^1.11.0",
-    "@muenchen/digiwf-form-renderer": "^1.11.0",
-    "@muenchen/digiwf-multi-file-input": "^1.11.0",
-    "@muenchen/digiwf-task-api-internal": "^1.11.0",
+    "@muenchen/digiwf-date-input": "^1.12.0",
+    "@muenchen/digiwf-dms-api-internal": "^1.12.0",
+    "@muenchen/digiwf-dms-input": "^1.12.0",
+    "@muenchen/digiwf-engine-api-internal": "^1.12.0",
+    "@muenchen/digiwf-form-renderer": "^1.12.0",
+    "@muenchen/digiwf-multi-file-input": "^1.12.0",
+    "@muenchen/digiwf-task-api-internal": "^1.12.0",
     "@muenchen/vjsf": "^2.21.14",
     "@tanstack/vue-query": "^4.19.1",
     "ajv": "^8.12.0",

--- a/digiwf-apps/packages/apps/digiwf-webcomponent/package-lock.json
+++ b/digiwf-apps/packages/apps/digiwf-webcomponent/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@muenchen/digiwf-webcomponent",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@muenchen/digiwf-webcomponent",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "dependencies": {
         "@coreui/coreui": "^5.0.0",
         "@coreui/vue": "^5.0.0",

--- a/digiwf-apps/packages/apps/digiwf-webcomponent/package.json
+++ b/digiwf-apps/packages/apps/digiwf-webcomponent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muenchen/digiwf-webcomponent",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "type": "module",
   "private": true,
   "scripts": {
@@ -16,8 +16,8 @@
     "@coreui/vue": "^5.0.0",
     "@jamescoyle/vue-icon": "^0.1.2",
     "@mdi/js": "^7.4.47",
-    "@muenchen/digiwf-engine-api-internal": "^1.11.0",
-    "@muenchen/digiwf-task-api-internal": "^1.11.0",
+    "@muenchen/digiwf-engine-api-internal": "^1.12.0",
+    "@muenchen/digiwf-task-api-internal": "^1.12.0",
     "@vueuse/core": "^10.9.0",
     "vue": "^3.4.21"
   },

--- a/digiwf-apps/packages/components/digiwf-date-input/package-lock.json
+++ b/digiwf-apps/packages/components/digiwf-date-input/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@muenchen/digiwf-date-input",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@muenchen/digiwf-date-input",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "devDependencies": {
         "@ianvs/prettier-plugin-sort-imports": "^4.1.1",
         "@muenchen/prettier-codeformat": "^1.0.1",

--- a/digiwf-apps/packages/components/digiwf-date-input/package.json
+++ b/digiwf-apps/packages/components/digiwf-date-input/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muenchen/digiwf-date-input",
   "description": "Customized component with possibility to enter date with keyboard",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "module": "dist/digiwf-date-input.mjs",
   "scripts": {
     "build": "vite build",
@@ -24,9 +24,7 @@
     "jest": "^28.1.3",
     "jest-environment-jsdom": "^29.5.0",
     "ts-jest": "^28.0.8",
-    "uuid": "latest",
-    "@ianvs/prettier-plugin-sort-imports": "^4.1.1",
-    "@muenchen/prettier-codeformat": "^1.0.1"
+    "uuid": "latest"
   },
   "files": [
     "dist/*",

--- a/digiwf-apps/packages/components/digiwf-dms-api-internal/package-lock.json
+++ b/digiwf-apps/packages/components/digiwf-dms-api-internal/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@muenchen/digiwf-dms-api-internal",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@muenchen/digiwf-dms-api-internal",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "devDependencies": {
         "@openapitools/openapi-generator-cli": "^2.9.0",
         "@types/node": "^18.7.13",

--- a/digiwf-apps/packages/components/digiwf-dms-api-internal/package.json
+++ b/digiwf-apps/packages/components/digiwf-dms-api-internal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muenchen/digiwf-dms-api-internal",
   "description": "Internal digiWF dms api",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "module": "dist/digiwf-dms-api-internal.mjs",
   "scripts": {
     "build": "vite build && tsc --emitDeclarationOnly",

--- a/digiwf-apps/packages/components/digiwf-dms-input/package-lock.json
+++ b/digiwf-apps/packages/components/digiwf-dms-input/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@muenchen/digiwf-dms-input",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@muenchen/digiwf-dms-input",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "devDependencies": {
         "@ianvs/prettier-plugin-sort-imports": "^4.1.1",
         "@muenchen/prettier-codeformat": "^1.0.1",

--- a/digiwf-apps/packages/components/digiwf-dms-input/package.json
+++ b/digiwf-apps/packages/components/digiwf-dms-input/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@muenchen/digiwf-dms-input",
   "description": "Customized component with possibility to read metadata from dms objects",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "module": "dist/digiwf-dms-input.mjs",
   "scripts": {
     "build": "vite build",
     "watch": "vite build --watch"
   },
   "dependencies": {
-    "@muenchen/digiwf-dms-api-internal": "^1.11.0"
+    "@muenchen/digiwf-dms-api-internal": "^1.12.0"
   },
   "peerDependencies": {
     "vue": "^2.7.0",
@@ -18,9 +18,7 @@
     "@ianvs/prettier-plugin-sort-imports": "^4.1.1",
     "@muenchen/prettier-codeformat": "^1.0.1",
     "axios": "^1.6.0",
-    "uuid": "^8.3.2",
-    "@ianvs/prettier-plugin-sort-imports": "^4.1.1",
-    "@muenchen/prettier-codeformat": "^1.0.1"
+    "uuid": "^8.3.2"
   },
   "files": [
     "dist/*",

--- a/digiwf-apps/packages/components/digiwf-engine-api-internal/package-lock.json
+++ b/digiwf-apps/packages/components/digiwf-engine-api-internal/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@muenchen/digiwf-engine-api-internal",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@muenchen/digiwf-engine-api-internal",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "dependencies": {
         "typescript": "^4.8.2"
       },

--- a/digiwf-apps/packages/components/digiwf-engine-api-internal/package.json
+++ b/digiwf-apps/packages/components/digiwf-engine-api-internal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muenchen/digiwf-engine-api-internal",
   "description": "Internal digiWF engine api",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "module": "dist/digiwf-engine-api-internal.mjs",
   "scripts": {
     "build": "vite build && tsc --emitDeclarationOnly",

--- a/digiwf-apps/packages/components/digiwf-form-builder-settings/package-lock.json
+++ b/digiwf-apps/packages/components/digiwf-form-builder-settings/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@muenchen/digiwf-form-builder-settings",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@muenchen/digiwf-form-builder-settings",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "devDependencies": {
         "@ianvs/prettier-plugin-sort-imports": "^4.1.1",
         "@muenchen/prettier-codeformat": "^1.0.1",

--- a/digiwf-apps/packages/components/digiwf-form-builder-settings/package.json
+++ b/digiwf-apps/packages/components/digiwf-form-builder-settings/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muenchen/digiwf-form-builder-settings",
   "description": "Form Builder Settings",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "module": "dist/digiwf-form-builder-settings.mjs",
   "scripts": {
     "build": "vite build",
@@ -23,9 +23,7 @@
     "@muenchen/prettier-codeformat": "^1.0.1",
     "@types/jest": "^29.2.5",
     "jest": "29.3.1",
-    "ts-jest": "^29.0.5",
-    "@ianvs/prettier-plugin-sort-imports": "^4.1.1",
-    "@muenchen/prettier-codeformat": "^1.0.1"
+    "ts-jest": "^29.0.5"
   },
   "gitHead": "b2b458745431c62fd6a055d9b3c32ce14b0c8435"
 }

--- a/digiwf-apps/packages/components/digiwf-form-builder/package-lock.json
+++ b/digiwf-apps/packages/components/digiwf-form-builder/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@muenchen/digiwf-form-builder",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@muenchen/digiwf-form-builder",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "devDependencies": {
         "@ianvs/prettier-plugin-sort-imports": "^4.1.1",
         "@muenchen/prettier-codeformat": "^1.0.1",

--- a/digiwf-apps/packages/components/digiwf-form-builder/package.json
+++ b/digiwf-apps/packages/components/digiwf-form-builder/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@muenchen/digiwf-form-builder",
   "description": "Form Builder",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "module": "dist/digiwf-form-builder.mjs",
   "scripts": {
     "build": "vite build",
     "watch": "vite build --watch"
   },
   "dependencies": {
-    "@muenchen/digiwf-form-builder-settings": "^1.11.0",
-    "@muenchen/digiwf-form-renderer": "^1.11.0"
+    "@muenchen/digiwf-form-builder-settings": "^1.12.0",
+    "@muenchen/digiwf-form-renderer": "^1.12.0"
   },
   "peerDependencies": {
     "vue": "^2.7.0",

--- a/digiwf-apps/packages/components/digiwf-form-renderer/package-lock.json
+++ b/digiwf-apps/packages/components/digiwf-form-renderer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@muenchen/digiwf-form-renderer",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@muenchen/digiwf-form-renderer",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "devDependencies": {
         "@ianvs/prettier-plugin-sort-imports": "^4.1.1",
         "@muenchen/prettier-codeformat": "^1.0.1",

--- a/digiwf-apps/packages/components/digiwf-form-renderer/package.json
+++ b/digiwf-apps/packages/components/digiwf-form-renderer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muenchen/digiwf-form-renderer",
   "description": "Form renderer",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "module": "dist/digiwf-form-renderer.mjs",
   "scripts": {
     "build": "vite build",

--- a/digiwf-apps/packages/components/digiwf-multi-file-input/package-lock.json
+++ b/digiwf-apps/packages/components/digiwf-multi-file-input/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@muenchen/digiwf-multi-file-input",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@muenchen/digiwf-multi-file-input",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "devDependencies": {
         "@ianvs/prettier-plugin-sort-imports": "^4.1.1",
         "@muenchen/prettier-codeformat": "^1.0.1",

--- a/digiwf-apps/packages/components/digiwf-multi-file-input/package.json
+++ b/digiwf-apps/packages/components/digiwf-multi-file-input/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muenchen/digiwf-multi-file-input",
   "description": "Form renderer",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "module": "dist/digiwf-multi-file-input.mjs",
   "scripts": {
     "build": "vite build",
@@ -9,8 +9,8 @@
     "test": "jest src"
   },
   "dependencies": {
-    "@muenchen/digiwf-engine-api-internal": "^1.11.0",
-    "@muenchen/digiwf-task-api-internal": "^1.11.0"
+    "@muenchen/digiwf-engine-api-internal": "^1.12.0",
+    "@muenchen/digiwf-task-api-internal": "^1.12.0"
   },
   "peerDependencies": {
     "vue": "^2.7.0",
@@ -31,9 +31,7 @@
     "mime": "^3.0.0",
     "ts-jest": "^28.0.8",
     "uuid": "^8.3.2",
-    "vue-pdf-embed": "^1.1.2",
-    "@ianvs/prettier-plugin-sort-imports": "^4.1.1",
-    "@muenchen/prettier-codeformat": "^1.0.1"
+    "vue-pdf-embed": "^1.1.2"
   },
   "files": [
     "dist/*",

--- a/digiwf-apps/packages/components/digiwf-task-api-internal/package-lock.json
+++ b/digiwf-apps/packages/components/digiwf-task-api-internal/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@muenchen/digiwf-task-api-internal",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@muenchen/digiwf-task-api-internal",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "dependencies": {
         "typescript": "^4.8.2"
       },

--- a/digiwf-apps/packages/components/digiwf-task-api-internal/package.json
+++ b/digiwf-apps/packages/components/digiwf-task-api-internal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@muenchen/digiwf-task-api-internal",
   "description": "Internal digiWF tasklist api",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "module": "dist/digiwf-task-api-internal.mjs",
   "scripts": {
     "build": "vite build && tsc --emitDeclarationOnly",

--- a/digiwf-apps/pom.xml
+++ b/digiwf-apps/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>de.muenchen.oss.digiwf</groupId>
     <artifactId>digiwf-core</artifactId>
-    <version>1.11.0-SNAPSHOT</version>
+    <version>1.12.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>digiwf-apps</artifactId>

--- a/digiwf-connector/digiwf-camunda-connector-service/pom.xml
+++ b/digiwf-connector/digiwf-camunda-connector-service/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-connector</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/digiwf-connector/digiwf-camunda-rest-connector-starter/pom.xml
+++ b/digiwf-connector/digiwf-camunda-rest-connector-starter/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-connector</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/digiwf-connector/digiwf-connector-starter/pom.xml
+++ b/digiwf-connector/digiwf-connector-starter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-connector</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-connector-starter</artifactId>

--- a/digiwf-connector/pom.xml
+++ b/digiwf-connector/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-parent</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
         <relativePath>../digiwf-parent</relativePath>
     </parent>
 

--- a/digiwf-coverage/pom.xml
+++ b/digiwf-coverage/pom.xml
@@ -12,7 +12,7 @@
         <artifactId>digiwf-parent</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <relativePath>../digiwf-parent</relativePath>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/digiwf-engine/digiwf-engine-cockpit/pom.xml
+++ b/digiwf-engine/digiwf-engine-cockpit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-engine</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-engine-cockpit</artifactId>

--- a/digiwf-engine/digiwf-engine-rest-service/pom.xml
+++ b/digiwf-engine/digiwf-engine-rest-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-engine</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/digiwf-engine/digiwf-engine-service/pom.xml
+++ b/digiwf-engine/digiwf-engine-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-engine</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/digiwf-engine/pom.xml
+++ b/digiwf-engine/pom.xml
@@ -7,7 +7,7 @@
         <artifactId>digiwf-parent</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <relativePath>../digiwf-parent</relativePath>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
 

--- a/digiwf-gateway/pom.xml
+++ b/digiwf-gateway/pom.xml
@@ -7,7 +7,7 @@
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-parent</artifactId>
         <relativePath>../digiwf-parent</relativePath>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-gateway</artifactId>

--- a/digiwf-integrations/digiwf-address-integration/digiwf-address-integration-client/pom.xml
+++ b/digiwf-integrations/digiwf-address-integration/digiwf-address-integration-client/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-address-integration</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-address-integration-client</artifactId>

--- a/digiwf-integrations/digiwf-address-integration/digiwf-address-integration-core/pom.xml
+++ b/digiwf-integrations/digiwf-address-integration/digiwf-address-integration-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-address-integration</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-address-integration-core</artifactId>

--- a/digiwf-integrations/digiwf-address-integration/digiwf-address-integration-service/pom.xml
+++ b/digiwf-integrations/digiwf-address-integration/digiwf-address-integration-service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-address-integration</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/digiwf-integrations/digiwf-address-integration/digiwf-address-integration-starter/pom.xml
+++ b/digiwf-integrations/digiwf-address-integration/digiwf-address-integration-starter/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-address-integration</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/digiwf-integrations/digiwf-address-integration/pom.xml
+++ b/digiwf-integrations/digiwf-address-integration/pom.xml
@@ -13,7 +13,7 @@
         <artifactId>digiwf-integration-parent</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <relativePath>../digiwf-integration-parent</relativePath>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/digiwf-integrations/digiwf-alw-integration/digiwf-alw-integration-core/pom.xml
+++ b/digiwf-integrations/digiwf-alw-integration/digiwf-alw-integration-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-alw-integration</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-alw-integration-core</artifactId>

--- a/digiwf-integrations/digiwf-alw-integration/digiwf-alw-integration-service/pom.xml
+++ b/digiwf-integrations/digiwf-alw-integration/digiwf-alw-integration-service/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-alw-integration</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-alw-integration-service</artifactId>

--- a/digiwf-integrations/digiwf-alw-integration/digiwf-alw-integration-starter/pom.xml
+++ b/digiwf-integrations/digiwf-alw-integration/digiwf-alw-integration-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-alw-integration</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-alw-integration-starter</artifactId>

--- a/digiwf-integrations/digiwf-alw-integration/pom.xml
+++ b/digiwf-integrations/digiwf-alw-integration/pom.xml
@@ -8,7 +8,7 @@
         <artifactId>digiwf-integration-parent</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <relativePath>../digiwf-integration-parent</relativePath>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-alw-integration</artifactId>

--- a/digiwf-integrations/digiwf-cosys-integration/digiwf-cosys-integration-client/pom.xml
+++ b/digiwf-integrations/digiwf-cosys-integration/digiwf-cosys-integration-client/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-cosys-integration</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/digiwf-integrations/digiwf-cosys-integration/digiwf-cosys-integration-core/pom.xml
+++ b/digiwf-integrations/digiwf-cosys-integration/digiwf-cosys-integration-core/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>digiwf-cosys-integration</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/digiwf-integrations/digiwf-cosys-integration/digiwf-cosys-integration-example/pom.xml
+++ b/digiwf-integrations/digiwf-cosys-integration/digiwf-cosys-integration-example/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>digiwf-cosys-integration</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/digiwf-integrations/digiwf-cosys-integration/digiwf-cosys-integration-service/pom.xml
+++ b/digiwf-integrations/digiwf-cosys-integration/digiwf-cosys-integration-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>digiwf-cosys-integration</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/digiwf-integrations/digiwf-cosys-integration/digiwf-cosys-integration-starter/pom.xml
+++ b/digiwf-integrations/digiwf-cosys-integration/digiwf-cosys-integration-starter/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>digiwf-cosys-integration</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/digiwf-integrations/digiwf-cosys-integration/pom.xml
+++ b/digiwf-integrations/digiwf-cosys-integration/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>digiwf-cosys-integration</artifactId>
     <packaging>pom</packaging>
-    <version>1.11.0-SNAPSHOT</version>
+    <version>1.12.0-SNAPSHOT</version>
     <name>digiwf-cosys-integration</name>
     <description>CoSys integration used by DigiWF</description>
 
@@ -14,7 +14,7 @@
         <artifactId>digiwf-integration-parent</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <relativePath>../digiwf-integration-parent</relativePath>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/digiwf-integrations/digiwf-dms-integration/digiwf-dms-integration-core/pom.xml
+++ b/digiwf-integrations/digiwf-dms-integration/digiwf-dms-integration-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>digiwf-dms-integration</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-dms-integration-core</artifactId>

--- a/digiwf-integrations/digiwf-dms-integration/digiwf-dms-integration-fabasoft/digiwf-dms-integration-fabasoft-api/pom.xml
+++ b/digiwf-integrations/digiwf-dms-integration/digiwf-dms-integration-fabasoft/digiwf-dms-integration-fabasoft-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>digiwf-dms-integration-fabasoft</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-dms-integration-fabasoft-api</artifactId>

--- a/digiwf-integrations/digiwf-dms-integration/digiwf-dms-integration-fabasoft/digiwf-dms-integration-fabasoft-mock-service/pom.xml
+++ b/digiwf-integrations/digiwf-dms-integration/digiwf-dms-integration-fabasoft/digiwf-dms-integration-fabasoft-mock-service/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>digiwf-dms-integration-fabasoft</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-dms-integration-fabasoft-mock-service</artifactId>

--- a/digiwf-integrations/digiwf-dms-integration/digiwf-dms-integration-fabasoft/digiwf-dms-integration-fabasoft-mock/pom.xml
+++ b/digiwf-integrations/digiwf-dms-integration/digiwf-dms-integration-fabasoft/digiwf-dms-integration-fabasoft-mock/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>digiwf-dms-integration-fabasoft</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-dms-integration-fabasoft-mock</artifactId>

--- a/digiwf-integrations/digiwf-dms-integration/digiwf-dms-integration-fabasoft/pom.xml
+++ b/digiwf-integrations/digiwf-dms-integration/digiwf-dms-integration-fabasoft/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>digiwf-dms-integration</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/digiwf-integrations/digiwf-dms-integration/digiwf-dms-integration-service/pom.xml
+++ b/digiwf-integrations/digiwf-dms-integration/digiwf-dms-integration-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>digiwf-dms-integration</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/digiwf-integrations/digiwf-dms-integration/digiwf-dms-integration-starter/pom.xml
+++ b/digiwf-integrations/digiwf-dms-integration/digiwf-dms-integration-starter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>digiwf-dms-integration</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-dms-integration-starter</artifactId>

--- a/digiwf-integrations/digiwf-dms-integration/pom.xml
+++ b/digiwf-integrations/digiwf-dms-integration/pom.xml
@@ -6,7 +6,7 @@
 
     <name>digiwf-dms-integration</name>
     <artifactId>digiwf-dms-integration</artifactId>
-    <version>1.11.0-SNAPSHOT</version>
+    <version>1.12.0-SNAPSHOT</version>
     <description>DMS integration used by DigiWF</description>
     <packaging>pom</packaging>
 
@@ -14,7 +14,7 @@
         <artifactId>digiwf-integration-parent</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <relativePath>../digiwf-integration-parent</relativePath>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/digiwf-integrations/digiwf-email-integration/digiwf-email-integration-core/pom.xml
+++ b/digiwf-integrations/digiwf-email-integration/digiwf-email-integration-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>digiwf-email-integration</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-email-integration-core</artifactId>

--- a/digiwf-integrations/digiwf-email-integration/digiwf-email-integration-example/pom.xml
+++ b/digiwf-integrations/digiwf-email-integration/digiwf-email-integration-example/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>digiwf-email-integration</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-email-integration-example</artifactId>

--- a/digiwf-integrations/digiwf-email-integration/digiwf-email-integration-service/pom.xml
+++ b/digiwf-integrations/digiwf-email-integration/digiwf-email-integration-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>digiwf-email-integration</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/digiwf-integrations/digiwf-email-integration/digiwf-email-integration-starter/pom.xml
+++ b/digiwf-integrations/digiwf-email-integration/digiwf-email-integration-starter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>digiwf-email-integration</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-email-integration-starter</artifactId>

--- a/digiwf-integrations/digiwf-email-integration/pom.xml
+++ b/digiwf-integrations/digiwf-email-integration/pom.xml
@@ -6,7 +6,7 @@
 
     <name>digiwf-email-integration</name>
     <artifactId>digiwf-email-integration</artifactId>
-    <version>1.11.0-SNAPSHOT</version>
+    <version>1.12.0-SNAPSHOT</version>
     <description>E-Mail integration used by DigiWF</description>
     <packaging>pom</packaging>
 
@@ -14,7 +14,7 @@
         <artifactId>digiwf-integration-parent</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <relativePath>../digiwf-integration-parent</relativePath>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/digiwf-integrations/digiwf-example-integration/digiwf-example-integration-core/pom.xml
+++ b/digiwf-integrations/digiwf-example-integration/digiwf-example-integration-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-example-integration</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-example-integration-core</artifactId>

--- a/digiwf-integrations/digiwf-example-integration/digiwf-example-integration-service/pom.xml
+++ b/digiwf-integrations/digiwf-example-integration/digiwf-example-integration-service/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-example-integration</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-example-integration-service</artifactId>

--- a/digiwf-integrations/digiwf-example-integration/digiwf-example-integration-starter/pom.xml
+++ b/digiwf-integrations/digiwf-example-integration/digiwf-example-integration-starter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-example-integration</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-example-integration-starter</artifactId>

--- a/digiwf-integrations/digiwf-example-integration/pom.xml
+++ b/digiwf-integrations/digiwf-example-integration/pom.xml
@@ -10,7 +10,7 @@
         <artifactId>digiwf-integration-parent</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <relativePath>../digiwf-integration-parent</relativePath>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/digiwf-integrations/digiwf-integration-parent/pom.xml
+++ b/digiwf-integrations/digiwf-integration-parent/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-integrations</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-integration-parent</artifactId>

--- a/digiwf-integrations/digiwf-okewo-integration/digiwf-okewo-integration-client/pom.xml
+++ b/digiwf-integrations/digiwf-okewo-integration/digiwf-okewo-integration-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-okewo-integration</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-okewo-integration-client</artifactId>

--- a/digiwf-integrations/digiwf-okewo-integration/digiwf-okewo-integration-core/pom.xml
+++ b/digiwf-integrations/digiwf-okewo-integration/digiwf-okewo-integration-core/pom.xml
@@ -4,13 +4,13 @@
 
     <artifactId>digiwf-okewo-integration-core</artifactId>
     <name>digiwf-okewo-integration-core</name>
-    <version>1.11.0-SNAPSHOT</version>
+    <version>1.12.0-SNAPSHOT</version>
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-okewo-integration</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/digiwf-integrations/digiwf-okewo-integration/digiwf-okewo-integration-service/pom.xml
+++ b/digiwf-integrations/digiwf-okewo-integration/digiwf-okewo-integration-service/pom.xml
@@ -4,13 +4,13 @@
 
     <artifactId>digiwf-okewo-integration-service</artifactId>
     <name>digiwf-okewo-integration-service</name>
-    <version>1.11.0-SNAPSHOT</version>
+    <version>1.12.0-SNAPSHOT</version>
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-okewo-integration</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/digiwf-integrations/digiwf-okewo-integration/digiwf-okewo-integration-starter/pom.xml
+++ b/digiwf-integrations/digiwf-okewo-integration/digiwf-okewo-integration-starter/pom.xml
@@ -5,12 +5,12 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>digiwf-okewo-integration-starter</artifactId>
     <name>digiwf-okewo-integration-starter</name>
-    <version>1.11.0-SNAPSHOT</version>
+    <version>1.12.0-SNAPSHOT</version>
 
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-okewo-integration</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/digiwf-integrations/digiwf-okewo-integration/pom.xml
+++ b/digiwf-integrations/digiwf-okewo-integration/pom.xml
@@ -6,7 +6,7 @@
 
     <name>digiwf-okewo-integration</name>
     <artifactId>digiwf-okewo-integration</artifactId>
-    <version>1.11.0-SNAPSHOT</version>
+    <version>1.12.0-SNAPSHOT</version>
     <description>OK.EWO integration used by DigiWF</description>
     <packaging>pom</packaging>
 
@@ -14,7 +14,7 @@
         <artifactId>digiwf-integration-parent</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <relativePath>../digiwf-integration-parent</relativePath>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-client-example/pom.xml
+++ b/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-client-example/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-s3-integration</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-client-starter/pom.xml
+++ b/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-client-starter/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-s3-integration</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-client/pom.xml
+++ b/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-client/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-s3-integration</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-core/pom.xml
+++ b/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-s3-integration</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-s3-integration-core</artifactId>

--- a/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-service/pom.xml
+++ b/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-service/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-s3-integration</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-s3-integration-service</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>de.muenchen.oss.digiwf</groupId>
             <artifactId>digiwf-s3-integration-starter</artifactId>
-            <version>1.11.0-SNAPSHOT</version>
+            <version>1.12.0-SNAPSHOT</version>
         </dependency>
 
         <!-- Security -->

--- a/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-starter/pom.xml
+++ b/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-s3-integration</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
 

--- a/digiwf-integrations/digiwf-s3-integration/pom.xml
+++ b/digiwf-integrations/digiwf-s3-integration/pom.xml
@@ -8,12 +8,12 @@
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-integration-parent</artifactId>
         <relativePath>../digiwf-integration-parent/pom.xml</relativePath>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
 
     <artifactId>digiwf-s3-integration</artifactId>
-    <version>1.11.0-SNAPSHOT</version>
+    <version>1.12.0-SNAPSHOT</version>
     <name>digiwf-s3-integration</name>
     <packaging>pom</packaging>
     <description>S3 integration used by DigiWF</description>

--- a/digiwf-integrations/digiwf-ticket-integration/digiwf-ticket-integration-core/pom.xml
+++ b/digiwf-integrations/digiwf-ticket-integration/digiwf-ticket-integration-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-ticket-integration</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-ticket-integration-core</artifactId>

--- a/digiwf-integrations/digiwf-ticket-integration/digiwf-ticket-integration-service/pom.xml
+++ b/digiwf-integrations/digiwf-ticket-integration/digiwf-ticket-integration-service/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-ticket-integration</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-ticket-integration-service</artifactId>

--- a/digiwf-integrations/digiwf-ticket-integration/digiwf-ticket-integration-starter/pom.xml
+++ b/digiwf-integrations/digiwf-ticket-integration/digiwf-ticket-integration-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-ticket-integration</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-ticket-integration-starter</artifactId>

--- a/digiwf-integrations/digiwf-ticket-integration/digiwf-ticket-integration-zammad-api/pom.xml
+++ b/digiwf-integrations/digiwf-ticket-integration/digiwf-ticket-integration-zammad-api/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-ticket-integration</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/digiwf-integrations/digiwf-ticket-integration/pom.xml
+++ b/digiwf-integrations/digiwf-ticket-integration/pom.xml
@@ -8,7 +8,7 @@
         <artifactId>digiwf-integration-parent</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <relativePath>../digiwf-integration-parent</relativePath>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-ticket-integration</artifactId>

--- a/digiwf-integrations/pom.xml
+++ b/digiwf-integrations/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-core</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-integrations</artifactId>

--- a/digiwf-libs/digiwf-camunda-prometheus/digiwf-camunda-prometheus-core/pom.xml
+++ b/digiwf-libs/digiwf-camunda-prometheus/digiwf-camunda-prometheus-core/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-camunda-prometheus</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/digiwf-libs/digiwf-camunda-prometheus/digiwf-camunda-prometheus-example/pom.xml
+++ b/digiwf-libs/digiwf-camunda-prometheus/digiwf-camunda-prometheus-example/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>digiwf-camunda-prometheus</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/digiwf-libs/digiwf-camunda-prometheus/digiwf-camunda-prometheus-starter/pom.xml
+++ b/digiwf-libs/digiwf-camunda-prometheus/digiwf-camunda-prometheus-starter/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>digiwf-camunda-prometheus</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/digiwf-libs/digiwf-camunda-prometheus/pom.xml
+++ b/digiwf-libs/digiwf-camunda-prometheus/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-libs</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-camunda-prometheus</artifactId>

--- a/digiwf-libs/digiwf-email/digiwf-email-api/pom.xml
+++ b/digiwf-libs/digiwf-email/digiwf-email-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-email</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-email-api</artifactId>

--- a/digiwf-libs/digiwf-email/digiwf-email-starter/pom.xml
+++ b/digiwf-libs/digiwf-email/digiwf-email-starter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-email</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-email-starter</artifactId>

--- a/digiwf-libs/digiwf-email/pom.xml
+++ b/digiwf-libs/digiwf-email/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-libs</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-email</artifactId>

--- a/digiwf-libs/digiwf-json-serialization/digiwf-json-serialization-core/pom.xml
+++ b/digiwf-libs/digiwf-json-serialization/digiwf-json-serialization-core/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-json-serialization</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/digiwf-libs/digiwf-json-serialization/digiwf-json-serialization-starter/pom.xml
+++ b/digiwf-libs/digiwf-json-serialization/digiwf-json-serialization-starter/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-json-serialization</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/digiwf-libs/digiwf-json-serialization/example-json-serialization/pom.xml
+++ b/digiwf-libs/digiwf-json-serialization/example-json-serialization/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-json-serialization</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-example-json-serialization</artifactId>

--- a/digiwf-libs/digiwf-json-serialization/pom.xml
+++ b/digiwf-libs/digiwf-json-serialization/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-libs</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-json-serialization</artifactId>

--- a/digiwf-libs/digiwf-message/digiwf-message-core/pom.xml
+++ b/digiwf-libs/digiwf-message/digiwf-message-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-message</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-message-core</artifactId>

--- a/digiwf-libs/digiwf-message/digiwf-message-example/pom.xml
+++ b/digiwf-libs/digiwf-message/digiwf-message-example/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-message</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-message-example</artifactId>

--- a/digiwf-libs/digiwf-message/digiwf-message-starter/pom.xml
+++ b/digiwf-libs/digiwf-message/digiwf-message-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-message</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-message-starter</artifactId>

--- a/digiwf-libs/digiwf-message/pom.xml
+++ b/digiwf-libs/digiwf-message/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-libs</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/digiwf-libs/digiwf-optimize-plugins/pom.xml
+++ b/digiwf-libs/digiwf-optimize-plugins/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-libs</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-optimize-plugins</artifactId>

--- a/digiwf-libs/digiwf-process/digiwf-process-api/pom.xml
+++ b/digiwf-libs/digiwf-process/digiwf-process-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-process</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/digiwf-libs/digiwf-process/digiwf-process-example/pom.xml
+++ b/digiwf-libs/digiwf-process/digiwf-process-example/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-process</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-process-example</artifactId>

--- a/digiwf-libs/digiwf-process/digiwf-process-starter/pom.xml
+++ b/digiwf-libs/digiwf-process/digiwf-process-starter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-process</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-process-starter</artifactId>

--- a/digiwf-libs/digiwf-process/pom.xml
+++ b/digiwf-libs/digiwf-process/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-libs</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-process</artifactId>

--- a/digiwf-libs/digiwf-spring-logging-and-tracing/pom.xml
+++ b/digiwf-libs/digiwf-spring-logging-and-tracing/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-libs</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-spring-logging-and-tracing</artifactId>

--- a/digiwf-libs/digiwf-spring-security/digiwf-spring-security-core/pom.xml
+++ b/digiwf-libs/digiwf-spring-security/digiwf-spring-security-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-spring-security</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
     <artifactId>digiwf-spring-security-core</artifactId>
 

--- a/digiwf-libs/digiwf-spring-security/digiwf-spring-security-starter/pom.xml
+++ b/digiwf-libs/digiwf-spring-security/digiwf-spring-security-starter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-spring-security</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-spring-security-starter</artifactId>

--- a/digiwf-libs/digiwf-spring-security/pom.xml
+++ b/digiwf-libs/digiwf-spring-security/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-libs</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-spring-security</artifactId>
     <packaging>pom</packaging>
-    <version>1.11.0-SNAPSHOT</version>
+    <version>1.12.0-SNAPSHOT</version>
     <name>digiwf-spring-security</name>
     <description>Spring Security Configuration used by DigiWF</description>
 

--- a/digiwf-libs/digiwf-testing/digiwf-e2e-test-core/pom.xml
+++ b/digiwf-libs/digiwf-testing/digiwf-e2e-test-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-testing</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-e2e-test-core</artifactId>

--- a/digiwf-libs/digiwf-testing/digiwf-e2e-test-starter/pom.xml
+++ b/digiwf-libs/digiwf-testing/digiwf-e2e-test-starter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-testing</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-e2e-test-starter</artifactId>

--- a/digiwf-libs/digiwf-testing/digiwf-unit-test/pom.xml
+++ b/digiwf-libs/digiwf-testing/digiwf-unit-test/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-testing</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-unit-test</artifactId>

--- a/digiwf-libs/digiwf-testing/pom.xml
+++ b/digiwf-libs/digiwf-testing/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-libs</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-testing</artifactId>

--- a/digiwf-libs/pom.xml
+++ b/digiwf-libs/pom.xml
@@ -8,7 +8,7 @@
         <artifactId>digiwf-parent</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <relativePath>../digiwf-parent/pom.xml</relativePath>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
 

--- a/digiwf-parent/pom.xml
+++ b/digiwf-parent/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-core</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-parent</artifactId>

--- a/digiwf-task/digiwf-polyflow-connector-starter/pom.xml
+++ b/digiwf-task/digiwf-polyflow-connector-starter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-task</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-polyflow-connector-starter</artifactId>

--- a/digiwf-task/digiwf-task-api/pom.xml
+++ b/digiwf-task/digiwf-task-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-task</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-task-api</artifactId>

--- a/digiwf-task/digiwf-task-itest/pom.xml
+++ b/digiwf-task/digiwf-task-itest/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-task</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-task-itest</artifactId>

--- a/digiwf-task/digiwf-tasklist-service/pom.xml
+++ b/digiwf-task/digiwf-tasklist-service/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <artifactId>digiwf-task</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-tasklist-service</artifactId>

--- a/digiwf-task/pom.xml
+++ b/digiwf-task/pom.xml
@@ -7,7 +7,7 @@
         <artifactId>digiwf-parent</artifactId>
         <groupId>de.muenchen.oss.digiwf</groupId>
         <relativePath>../digiwf-parent</relativePath>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>digiwf-task</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>de.muenchen.oss.digiwf</groupId>
     <artifactId>digiwf-core</artifactId>
-    <version>1.11.0-SNAPSHOT</version>
+    <version>1.12.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>digiwf-docs</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>de.muenchen.oss.digiwf</groupId>
     <artifactId>digiwf-core</artifactId>
     <name>digiwf-core</name>
-    <version>1.11.0-SNAPSHOT</version>
+    <version>1.12.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>DigiWF Core Services</description>
     <url>https://github.com/it-at-m/digiwf-core</url>


### PR DESCRIPTION
* chore: mvn auto version bump to 1.12.0-SNAPSHOT

* v1.12.0

---------

### Check-List
- [x] [Internal Review]([https://github.com/it-at-m/digiwf-core/blob/dev/CHANGELOG.md](https://confluence.muenchen.de/display/MPdZ/Review+-+DigiWF)) is maintained
