### PR TITLE
HOWTO concatenate two arrays in a script task

### DIFF
--- a/docs/src/.vuepress/config.js
+++ b/docs/src/.vuepress/config.js
@@ -214,6 +214,13 @@ module.exports = {
                                 'templates/element-templates/',
                                 'templates/examples/'
                             ]
+                        },
+                        {
+                            title: 'Best Practices',
+                            collapsable: false,
+                            children: [
+                                'bestpractices/'
+                            ]
                         }
                     ],
                     '/integrations/': [

--- a/docs/src/modeling/bestpractices/README.md
+++ b/docs/src/modeling/bestpractices/README.md
@@ -1,0 +1,41 @@
+# Umgang mit JSON-Arrays
+
+## Elementzugriff
+
+Um auf die Elemente eines JSON-Arrays zugreifen zu können, kann die
+Klasse [SpinList](https://javadoc.io/doc/org.camunda.spin/camunda-spin-core/latest/org/camunda/spin/SpinList.html) von
+Camunda genutzt werden. Das unten stehende Beispiel aus einem Script-Task zeigt den Zugriff auf das erste Element einer
+Liste, das in eine neue Variable gespeichert wird.
+
+```
+/*
+* Erstes Element aus der Liste der DMS-COOs
+* an eine Variable des Execution-Context uebergeben.
+*/
+const fileCoos = execution.getVariable('sachakten');
+const spinListFileCoos = S(execution.getVariable('sachakten')).elements(); //SpinList
+const firstCoo = spinListFileCoos.get(0);
+execution.setVariable('firstCoo', firstCoo);
+```
+
+## Konkatenieren
+
+Um zwei Listen zusammenzuführen und sie wiederum an eine Prozessvariable zu übergeben, kann die Methode `addAll()`
+der [SpinList](https://javadoc.io/doc/org.camunda.spin/camunda-spin-core/latest/org/camunda/spin/SpinList.html)
+verwendet werden. Da für Listen von COO-Nummern pures JSON-Array verwendet wird, was valides JSON ist, muss die Liste
+zunächst mit `toString` ausgegeben und mit `S()` wieder in ein JSON-Objekt umgewandelt werden. Eine direktere
+Variante ist leider nicht bekannt.
+
+```
+const coos_1 = execution.getVariable('coos_1');
+const coos_2 = execution.getVariable('coos_2');
+
+const coosSpinList_1 = S(coos_1).elements(); //SpinList
+const coosSpinList_2 = S(coos_2).elements(); //SpinList
+
+coosSpinList_1.addAll(coosSpinList_2);
+
+execution.setVariable('contentCoos', S(coosSpinList_1.toString()));
+```
+
+Die Variable 'contentCoos' ist nun vom Typ `Json`.

--- a/docs/src/modeling/expressions/functions/README.md
+++ b/docs/src/modeling/expressions/functions/README.md
@@ -44,30 +44,3 @@ interagieren. Über die `execution` sind eine Vielzahl an Funktionen bereit, fol
 | `getVariable(key)`        | Lädt eine bestimmte Variable aus dem Execution Context     | `${execution.getVariable('starterOfInstance')}`          |
 | `setVariable(key, value)` | Setzt eine bestimmte Variable im Execution Context         | `${execution.setVariable('meineVariable', 'Mein Wert')}` |
 | `hasVariable(key)`        | Prüft, ob eine Variable im Execution Context vorhanden ist | `${execution.hasVariable('meineVariable')}`              |
-
-### Umgang mit Listen
-
-Um auf die Elemente einer Liste zugreifen zu können, muss die Variable zunächst geparst werden. Das unten stehende
-Beispiel aus einem Script-Task zeigt den Zugriff auf das erste Element einer Liste, das in eine neue Variable
-gespeichert wird.
-
-```
-/*
-* Erstes Element aus der Liste der DMS-COOs
-* an eine Variable des Execution-Context uebergeben.
-*/
-const tFileCoos = JSON.parse(execution.getVariable('sachakten'));
-const tFirstCoo = tFileCoos[0];
-execution.setVariable('firstCoo', tFirstCoo);
-```
-
-Um zwei Listen zusammenzuführen und sie wiederum an eine Prozessvariable zu übergeben, muss die zusammengeführte Liste 
-mit `S()` serialisiert werden. Folgendes Beispiel zeigt die Zusammenführung von zwei Listen.
-
-```
-const list_1 = JSON.parse(execution.getVariable('list_1'));
-const list_2 = JSON.parse(execution.getVariable('list_2'));
-const listCon = list_1.concat(list_2);
-const listConString = JSON.stringify(listCon);
-execution.setVariable('contentCoosString', S(listConString));
-```

--- a/docs/src/modeling/expressions/functions/README.md
+++ b/docs/src/modeling/expressions/functions/README.md
@@ -45,6 +45,8 @@ interagieren. Über die `execution` sind eine Vielzahl an Funktionen bereit, fol
 | `setVariable(key, value)` | Setzt eine bestimmte Variable im Execution Context         | `${execution.setVariable('meineVariable', 'Mein Wert')}` |
 | `hasVariable(key)`        | Prüft, ob eine Variable im Execution Context vorhanden ist | `${execution.hasVariable('meineVariable')}`              |
 
+### Umgang mit Listen
+
 Um auf die Elemente einer Liste zugreifen zu können, muss die Variable zunächst geparst werden. Das unten stehende
 Beispiel aus einem Script-Task zeigt den Zugriff auf das erste Element einer Liste, das in eine neue Variable
 gespeichert wird.
@@ -57,4 +59,15 @@ gespeichert wird.
 const tFileCoos = JSON.parse(execution.getVariable('sachakten'));
 const tFirstCoo = tFileCoos[0];
 execution.setVariable('firstCoo', tFirstCoo);
+```
+
+Um zwei Listen zusammenzuführen und sie wiederum an eine Prozessvariable zu übergeben, muss die zusammengeführte Liste 
+mit `S()` serialisiert werden. Folgendes Beispiel zeigt die Zusammenführung von zwei Listen.
+
+```
+const list_1 = JSON.parse(execution.getVariable('list_1'));
+const list_2 = JSON.parse(execution.getVariable('list_2'));
+const listCon = list_1.concat(list_2);
+const listConString = JSON.stringify(listCon);
+execution.setVariable('contentCoosString', S(listConString));
 ```


### PR DESCRIPTION
### Description
<!-- Brief explanation of the changes and their impact -->
Small documentation how to concatenate arrays in a script task.

### Reference

Issues: #xxx

### Screenshots (If UI changed)


### Check-List

- [x] [Internal Review]([https://github.com/it-at-m/digiwf-core/blob/dev/CHANGELOG.md](https://confluence.muenchen.de/display/MPdZ/Review+-+DigiWF)) is maintained
- [x] Documentations [external](https://github.com/it-at-m/digiwf-core/tree/dev/docs) and [internal](https://wiki.muenchen.de/betriebshandbuch/index.php?title=DigiWF&sfr=betriebshandbuch) are completed
- [x] No waste on Branch left (e.g. `console.logs`)
- [x] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
