### PR TITLE
#1706 Fix the property mismatch in Annotation CronJobConfiguration of s3-integration-starter

### DIFF
--- a/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-starter/src/main/java/de/muenchen/oss/digiwf/s3/integration/configuration/CronJobConfiguration.java
+++ b/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-starter/src/main/java/de/muenchen/oss/digiwf/s3/integration/configuration/CronJobConfiguration.java
@@ -12,7 +12,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 @Configuration
 @RequiredArgsConstructor
 @ConditionalOnProperty(
-    prefix = "de.muenchen.oss.digiwf.s3.cronjob.cleanup",
+    prefix = "io.muenchendigital.digiwf.s3.cronjob.cleanup",
     name = {
         "expired-files",
         "unused-files"


### PR DESCRIPTION
### Description

Fix the property mismatch in Annotation CronJobConfiguration of s3-integration-starter

### Reference

Issues: #1706

### Check-List

- [ ] All Acceptance criteria of user story are met
- [ ] Accessibility was considered and tested (On UI Change)
- [ ] JUnit tests are written (60% CodeCov)
- [ ] [Internal Review]([https://github.com/it-at-m/digiwf-core/blob/dev/CHANGELOG.md](https://confluence.muenchen.de/display/MPdZ/Review+-+DigiWF)) is maintained
- [ ] Documentations [external](https://github.com/it-at-m/digiwf-core/tree/dev/docs) and [internal](https://wiki.muenchen.de/betriebshandbuch/index.php?title=DigiWF&sfr=betriebshandbuch) are completed
- [ ] Smoketest successful (Manual E2E-Test depending on Change)
- [ ] No waste on Branch left (e.g. `console.logs`)
- [ ] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
- [ ] Internal Services / Artifacts updated (Depending on Change - See Dependency Graph)
- [ ] Openshift environments are prepared (Secrets, etc.) and release-issue is maintained
