### PR TITLE
.github ci use new docs deployment

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -13,5 +13,5 @@ jobs:
   build:
     uses: ./.github/workflows/workflow-build-docs.yaml
     with:
-      publish: false
+      publish: true
     secrets: inherit

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -13,5 +13,5 @@ jobs:
   build:
     uses: ./.github/workflows/workflow-build-docs.yaml
     with:
-      publish: true
+      publish: false
     secrets: inherit

--- a/.github/workflows/workflow-build-docs.yaml
+++ b/.github/workflows/workflow-build-docs.yaml
@@ -8,6 +8,13 @@ on:
         type: boolean
         required: true
         default: false
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Publish docs?'
+        type: boolean
+        required: true
+        default: false
 
 permissions:
   contents: read

--- a/.github/workflows/workflow-build-docs.yaml
+++ b/.github/workflows/workflow-build-docs.yaml
@@ -35,6 +35,15 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs/dist
+
+  deploy-docs:
+    if: inputs.publish == true
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build-docs
+    runs-on: ubuntu-latest
+    steps:
       - name: Deploy to GitHub Pages
-        if: inputs.publish == true
+        id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/workflow-build-docs.yaml
+++ b/.github/workflows/workflow-build-docs.yaml
@@ -9,6 +9,11 @@ on:
         required: true
         default: false
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   build-docs:
     runs-on: ubuntu-latest
@@ -25,9 +30,11 @@ jobs:
           cache-dependency-path: "./docs/package-lock.json"
       - run: npm install
       - run: npm run build
-      - name: Deploy
+      - name: Upload artifact
         if: inputs.publish == true
-        uses: peaceiris/actions-gh-pages@v4
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/dist
+          path: ./docs/dist
+      - name: Deploy to GitHub Pages
+        if: inputs.publish == true
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/workflow-build-docs.yaml
+++ b/.github/workflows/workflow-build-docs.yaml
@@ -28,7 +28,7 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
           cache-dependency-path: "./docs/package-lock.json"
-      - run: npm install
+      - run: npm ci
       - run: npm run build
       - name: Upload artifact
         if: inputs.publish == true

--- a/.github/workflows/workflow-build-docs.yaml
+++ b/.github/workflows/workflow-build-docs.yaml
@@ -8,13 +8,6 @@ on:
         type: boolean
         required: true
         default: false
-  workflow_dispatch:
-    inputs:
-      publish:
-        description: 'Publish docs?'
-        type: boolean
-        required: true
-        default: false
 
 permissions:
   contents: read


### PR DESCRIPTION
### Description
<!-- Brief explanation of the changes and their impact -->

Replace custom docs deploy action with new github builtin.

### Reference

https://github.com/it-at-m/.github/pull/11

### Check-List

- [x] Smoketest successful (Manual E2E-Test depending on Change)
- [x] No waste on Branch left (e.g. `console.logs`)
- [x] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
