### PR TITLE
dms-integration fix path concatenation

### DIFF
--- a/digiwf-integrations/digiwf-dms-integration/digiwf-dms-integration-core/src/main/java/de/muenchen/oss/digiwf/dms/integration/adapter/out/s3/S3Adapter.java
+++ b/digiwf-integrations/digiwf-dms-integration/digiwf-dms-integration-core/src/main/java/de/muenchen/oss/digiwf/dms/integration/adapter/out/s3/S3Adapter.java
@@ -58,10 +58,12 @@ public class S3Adapter implements LoadFileOutPort, TransferContentOutPort {
             final List<Content> contents = new ArrayList<>();
             final Set<String> filepath;
             filepath = documentStorageFolderRepository.getAllFilesInFolderRecursively(folderpath, domainSpecificS3Storage).block();
-            if (Objects.isNull(filepath)) throw new BpmnError(LOAD_FOLDER_FAILED, "An folder could not be loaded from url: " + folderpath);
+            if (Objects.isNull(filepath))
+                throw new BpmnError(LOAD_FOLDER_FAILED, "An folder could not be loaded from url: " + folderpath);
             filepath.forEach(file -> contents.add(getFile(file, domainSpecificS3Storage)));
             return contents;
-        } catch (final DocumentStorageException | DocumentStorageServerErrorException | DocumentStorageClientErrorException e) {
+        } catch (final DocumentStorageException | DocumentStorageServerErrorException |
+                       DocumentStorageClientErrorException e) {
             throw new BpmnError(LOAD_FOLDER_FAILED, "An folder could not be loaded from url: " + folderpath);
         }
     }
@@ -78,7 +80,8 @@ public class S3Adapter implements LoadFileOutPort, TransferContentOutPort {
                 throw new BpmnError("FILE_TYPE_NOT_SUPPORTED", "The type of this file is not supported: " + filepath);
 
             return new Content(fileExtensionService.getFileExtension(mimeType), filename, bytes);
-        } catch (final DocumentStorageException | DocumentStorageServerErrorException | DocumentStorageClientErrorException e) {
+        } catch (final DocumentStorageException | DocumentStorageServerErrorException |
+                       DocumentStorageClientErrorException e) {
             throw new BpmnError("LOAD_FILE_FAILED", "An file could not be loaded from url: " + filepath);
         }
     }
@@ -96,7 +99,8 @@ public class S3Adapter implements LoadFileOutPort, TransferContentOutPort {
 
         for (val file : content) {
             try {
-                this.documentStorageFileRepository.saveFile(fullPath + "/" + file.getName() + "." + file.getExtension(), file.getContent(), 1, null,
+                val fullFilePath = (fullPath + "/" + file.getName() + "." + file.getExtension()).replace("//", "/");
+                this.documentStorageFileRepository.saveFile(fullFilePath, file.getContent(), 1, null,
                         s3Storage);
             } catch (Exception e) {
                 throw new BpmnError("SAVE_FILE_FAILED", "An file could not be saved to path: " + fullPath);

--- a/digiwf-integrations/digiwf-dms-integration/digiwf-dms-integration-core/src/test/java/de/muenchen/oss/digiwf/dms/integration/adapter/out/s3/S3AdapterTest.java
+++ b/digiwf-integrations/digiwf-dms-integration/digiwf-dms-integration-core/src/test/java/de/muenchen/oss/digiwf/dms/integration/adapter/out/s3/S3AdapterTest.java
@@ -279,4 +279,23 @@ class S3AdapterTest {
         }
 
     }
+
+    @Test
+    void testTransferContent() throws IOException, DocumentStorageException, DocumentStorageClientErrorException, DocumentStorageServerErrorException {
+        when(processConfigApi.getProcessConfig(anyString())).thenThrow(new RuntimeException("Process Config does not exist"));
+        final String folderPathWithSlash = "folder/";
+        final String folderPathWithoutSlash = "folder";
+        final String fileContext = "files";
+        final byte[] testPdf = new ClassPathResource("files/test/test-pdf.pdf").getInputStream().readAllBytes();
+        final Content pdfContent = new Content("pdf", "test-pdf", testPdf);
+        final String fullPath = String.format("%s/%s/%s", fileContext, folderPathWithoutSlash, "test-pdf.pdf");
+        final String fullPathWrong = String.format("%s/%s//%s", fileContext, folderPathWithoutSlash, "test-pdf.pdf");
+
+        this.s3Adapter.transferContent(List.of(pdfContent), folderPathWithSlash, fileContext, processDefinitionId);
+        this.s3Adapter.transferContent(List.of(pdfContent), folderPathWithoutSlash, fileContext, processDefinitionId);
+
+        verify(documentStorageFileRepository, never()).saveFile(eq(fullPathWrong), any(), anyInt(), isNull(), anyString());
+        verify(documentStorageFileRepository, times(2)).saveFile(eq(fullPath), any(), anyInt(), isNull(), anyString());
+
+    }
 }


### PR DESCRIPTION
### Description

<!-- Brief explanation of the changes and their impact -->

Fix duplicate slash in dms-integration path concatenation for s3 adapter.

### Reference

- https://git.muenchen.de/digitalisierung/digiwf/digiwf-support/-/issues/465

### Check-List

- [x] JUnit tests are written (60% CodeCov)
- [x] No waste on Branch left (e.g. `console.logs`)
- [x] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
