### PR TITLE
openai-integration fix embedded kafka for spring 3.2.4

### DIFF
--- a/digiwf-integrations/digiwf-openai-integration/digiwf-openai-integration-service/src/test/resources/application-itest.yml
+++ b/digiwf-integrations/digiwf-openai-integration/digiwf-openai-integration-service/src/test/resources/application-itest.yml
@@ -1,18 +1,18 @@
 digiwf:
-    openai:
-        api-key: '123'
-        model: 'gpt-35-turbo'
-        max-tokens: 5
-        logging: true
-        base-url: 'http://localhost:8189/'
+  openai:
+    api-key: '123'
+    model: 'gpt-35-turbo'
+    max-tokens: 5
+    logging: true
+    base-url: 'http://localhost:8189/'
 
 spring:
-    cloud:
-        function:
-            definition: functionRouter;sendMessage;integrationTestConsumer;
-
+  cloud:
+    function:
+      definition: functionRouter;sendMessage;integrationTestConsumer;
+    stream:
+      kafka:
+        binder:
+          brokers: ${spring.embedded.kafka.brokers}
 # overwrite vars
 DIGIWF_ENV: itest
-KAFKA_BOOTSTRAP_SERVER: localhost
-KAFKA_BOOTSTRAP_SERVER_PORT: 19999
-KAFKA_SECURITY_PROTOCOL: PLAINTEXT


### PR DESCRIPTION
### Description

<!-- Brief explanation of the changes and their impact -->

Fix openai-integration embedded kafka test with spring 2.3.4

### Reference

#1536

### Check-List

- [x] Smoketest successful (Manual E2E-Test depending on Change)
- [x] No waste on Branch left (e.g. `console.logs`)
- [x] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
