### PR TITLE
Revert "flyway add dependencies for db types"

### DIFF
--- a/digiwf-engine/digiwf-engine-service/pom.xml
+++ b/digiwf-engine/digiwf-engine-service/pom.xml
@@ -199,13 +199,7 @@
 
         <dependency>
             <groupId>org.flywaydb</groupId>
-            <artifactId>flyway-database-oracle</artifactId>
-            <version>${flyway.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.flywaydb</groupId>
-            <artifactId>flyway-database-postgresql</artifactId>
-            <version>${flyway.version}</version>
+            <artifactId>flyway-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>

--- a/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-service/pom.xml
+++ b/digiwf-integrations/digiwf-s3-integration/digiwf-s3-integration-service/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -51,8 +51,7 @@
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>
-            <artifactId>flyway-database-postgresql</artifactId>
-            <version>${flyway.version}</version>
+            <artifactId>flyway-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/digiwf-parent/pom.xml
+++ b/digiwf-parent/pom.xml
@@ -19,7 +19,6 @@
         <spring-boot.version>3.2.4</spring-boot.version>
         <spring.cloud.version>2023.0.1</spring.cloud.version>
         <springdoc-openapi.version>2.5.0</springdoc-openapi.version>
-        <flyway.version>10.15.2</flyway.version>
         <okhttp.version>4.12.0</okhttp.version>
         <tika.version>2.9.2</tika.version>
         <archunit.version>1.3.0</archunit.version>

--- a/digiwf-task/digiwf-tasklist-service/pom.xml
+++ b/digiwf-task/digiwf-tasklist-service/pom.xml
@@ -168,8 +168,7 @@
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>
-            <artifactId>flyway-database-postgresql</artifactId>
-            <version>${flyway.version}</version>
+            <artifactId>flyway-core</artifactId>
         </dependency>
 
         <!-- Test -->


### PR DESCRIPTION
This reverts commit 0b6381ebb2c0f2ff2dee73805dc5cef1bd7c9855.

### Description

<!-- Brief explanation of the changes and their impact -->
Flyway add dependencies for oracle db.

Fix GitHub wrong diff from #1819 #1818

### Check-List

- [x] Smoketest successful (Manual E2E-Test depending on Change)
- [x] No waste on Branch left (e.g. `console.logs`)
- [x] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
