### PR TITLE
:bug: mail-integration fix filename without extension

### DIFF
--- a/digiwf-integrations/digiwf-email-integration/digiwf-email-integration-core/src/main/java/de/muenchen/oss/digiwf/email/integration/adapter/out/s3/S3Adapter.java
+++ b/digiwf-integrations/digiwf-email-integration/digiwf-email-integration-core/src/main/java/de/muenchen/oss/digiwf/email/integration/adapter/out/s3/S3Adapter.java
@@ -88,7 +88,7 @@ public class S3Adapter implements LoadMailAttachmentOutPort {
             final byte[] bytes;
             bytes = this.documentStorageFileRepository.getFile(filePath, 3, s3DomainService.getDefaultDocumentStorageUrl());
             final String mimeType = fileService.detectFileType(bytes);
-            final String filename = FilenameUtils.getBaseName(filePath);
+            final String filename = FilenameUtils.getName(filePath);
             final ByteArrayDataSource file = new ByteArrayDataSource(bytes, mimeType);
 
             // check if mimeType exists


### PR DESCRIPTION
### Description

<!-- Brief explanation of the changes and their impact -->

Fix file extension missing in mail attachments when using mail send without presigned urls.

### Reference

Introduced with #1734

### Screenshots (If UI changed)

### Check-List

- [x] [Internal Review](https://confluence.muenchen.de/display/MPdZ/Review+-+DigiWF) is maintained
- [x] Smoketest successful (Manual E2E-Test depending on Change)
- [x] No waste on Branch left (e.g. `console.logs`)
- [x] [Board](https://app.zenhub.com/workspaces/digiwf-621f70bf50ea1100120b7e93/board) is up-to-date
