### PR TITLE
maint/ci-disable-ee-build

### DIFF
--- a/.github/workflows/workflow-build-services.yaml
+++ b/.github/workflows/workflow-build-services.yaml
@@ -218,6 +218,7 @@ jobs:
           tags: itatm/digiwf-openai-integration-service:${{ inputs.release-version }}
 
   build-services-camunda-ee:
+    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository

--- a/.github/workflows/workflow-build-services.yaml
+++ b/.github/workflows/workflow-build-services.yaml
@@ -218,7 +218,7 @@ jobs:
           tags: itatm/digiwf-openai-integration-service:${{ inputs.release-version }}
 
   build-services-camunda-ee:
-    if: false
+    if: false # disable ee build
     runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository


### PR DESCRIPTION
### Description

<!-- Brief explanation of the changes and their impact -->

CI disable ee (enterprise edition) build, to only use Camunda community-edition.

### Reference

Issues: https://git.muenchen.de/digitalisierung/digiwf/digiwf-support/-/issues/479

### Screenshots (If UI changed)

### Check-List

- [x] Smoketest successful (Manual E2E-Test depending on Change)
- [x] No waste on Branch left (e.g. `console.logs`)
- [x] Internal Services / Artifacts updated (Depending on Change -
  See [Dependency Graph](https://wiki.muenchen.de/betriebshandbuch/wiki/DigiWF#Abh.C3.A4ngigkeiten)
- [x] Openshift environments are prepared (Secrets, etc.) and release-issue is maintained
